### PR TITLE
feat(result): display structured ingredient list on product detail page

### DIFF
--- a/e2e/result-page.spec.ts
+++ b/e2e/result-page.spec.ts
@@ -94,7 +94,7 @@ test.describe('Result page (/result/[barcode])', () => {
   test('ingredients_list_displayed_when_available', async ({ page }) => {
     await mockProductApi(page, VALID_BARCODE, vermeiden);
     await page.goto(`/result/${VALID_BARCODE}`);
-    await expect(page.getByText('Zutaten')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: 'Zutaten' })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText(/sugar, palm oil, hazelnuts/i)).toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/result-page.spec.ts
+++ b/e2e/result-page.spec.ts
@@ -90,4 +90,11 @@ test.describe('Result page (/result/[barcode])', () => {
     await page.getByRole('link', { name: /zurück zum scanner/i }).click();
     await expect(page).toHaveURL('/scanner');
   });
+
+  test('ingredients_list_displayed_when_available', async ({ page }) => {
+    await mockProductApi(page, VALID_BARCODE, vermeiden);
+    await page.goto(`/result/${VALID_BARCODE}`);
+    await expect(page.getByText('Zutaten')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/sugar, palm oil, hazelnuts/i)).toBeVisible({ timeout: 5000 });
+  });
 });

--- a/e2e/result-page.spec.ts
+++ b/e2e/result-page.spec.ts
@@ -97,4 +97,14 @@ test.describe('Result page (/result/[barcode])', () => {
     await expect(page.getByRole('heading', { name: 'Zutaten' })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText(/sugar, palm oil, hazelnuts/i)).toBeVisible({ timeout: 5000 });
   });
+
+  test('no_ingredients_info_message_when_ingredientslist_missing', async ({ page }) => {
+    const productWithoutIngredients = { ...vermeiden };
+    // @ts-expect-error — deliberately removing ingredientsList for test
+    delete productWithoutIngredients.ingredientsList;
+    await mockProductApi(page, VALID_BARCODE, productWithoutIngredients);
+    await page.goto(`/result/${VALID_BARCODE}`);
+    await expect(page.getByRole('heading', { name: 'Zutaten' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/Es sind keine Zutaten zu dem Produkt gespeichert/i)).toBeVisible({ timeout: 5000 });
+  });
 });

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -202,6 +202,18 @@ export function ScoreCard({
         </div>
       </div>
 
+      {/* Ingredients List */}
+      {product.ingredientsList && product.ingredientsList.length > 0 && (
+        <div className="border-t border-border px-5 py-5">
+          <h3 className="mb-4 text-base font-semibold text-foreground">
+            Zutaten
+          </h3>
+          <p className="text-base text-foreground leading-relaxed">
+            {product.ingredientsList.join(", ")}
+          </p>
+        </div>
+      )}
+
       {/* Action Buttons */}
       <div className="flex gap-3 border-t border-border p-5">
         <button

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -210,7 +210,7 @@ export function ScoreCard({
         {product.ingredientsList && product.ingredientsList.length > 0 ? (
           <>
             <p className="text-base text-foreground leading-relaxed">
-              {product.ingredientsList.join(", ")}
+              {product.ingredientsList.map(i => i.charAt(0).toUpperCase() + i.slice(1)).join(", ")}
             </p>
             <div className="flex items-start gap-2 mt-3 rounded-lg bg-muted/50 px-4 py-3">
               <Info className="h-5 w-5 shrink-0 mt-0.5 text-muted-foreground" />

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -203,16 +203,23 @@ export function ScoreCard({
       </div>
 
       {/* Ingredients List */}
-      {product.ingredientsList && product.ingredientsList.length > 0 && (
-        <div className="border-t border-border px-5 py-5">
-          <h3 className="mb-4 text-base font-semibold text-foreground">
-            Zutaten
-          </h3>
+      <div className="border-t border-border px-5 py-5">
+        <h3 className="mb-4 text-base font-semibold text-foreground">
+          Zutaten
+        </h3>
+        {product.ingredientsList && product.ingredientsList.length > 0 ? (
           <p className="text-base text-foreground leading-relaxed">
             {product.ingredientsList.join(", ")}
           </p>
-        </div>
-      )}
+        ) : (
+          <div className="flex items-start gap-2.5 rounded-lg bg-muted/50 px-4 py-3">
+            <Info className="h-5 w-5 shrink-0 mt-0.5 text-muted-foreground" />
+            <p className="text-base text-muted-foreground leading-relaxed">
+              Es sind keine Zutaten zu dem Produkt gespeichert! Dadurch können bestimmte Inhaltsstoffe nicht in die Bewertung einfließen.
+            </p>
+          </div>
+        )}
+      </div>
 
       {/* Action Buttons */}
       <div className="flex gap-3 border-t border-border p-5">

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -208,9 +208,17 @@ export function ScoreCard({
           Zutaten
         </h3>
         {product.ingredientsList && product.ingredientsList.length > 0 ? (
-          <p className="text-base text-foreground leading-relaxed">
-            {product.ingredientsList.join(", ")}
-          </p>
+          <>
+            <p className="text-base text-foreground leading-relaxed">
+              {product.ingredientsList.join(", ")}
+            </p>
+            <div className="flex items-start gap-2 mt-3 rounded-lg bg-muted/50 px-4 py-3">
+              <Info className="h-5 w-5 shrink-0 mt-0.5 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Es ist nicht gewährleistet, dass die Liste der Zutaten vollständig ist. Bitte prüfen Sie im Zweifelsfall selber nochmal das Produkt.
+              </p>
+            </div>
+          </>
         ) : (
           <div className="flex items-start gap-2.5 rounded-lg bg-muted/50 px-4 py-3">
             <Info className="h-5 w-5 shrink-0 mt-0.5 text-muted-foreground" />

--- a/src/core/domain/product.ts
+++ b/src/core/domain/product.ts
@@ -17,6 +17,7 @@ export interface Product {
   nutriments: Nutriments;
   labels: string[];
   ingredients: string;
+  ingredientsList?: string[];
   categories: string[];
   additives: string[];
 }

--- a/src/core/ports/product-repository.ts
+++ b/src/core/ports/product-repository.ts
@@ -4,5 +4,4 @@ export interface IProductRepository {
   findByBarcode(barcode: string): Promise<Product | null>;
   search(query: SearchQuery): Promise<SearchResult>;
   updateNutriments(barcode: string, nutriments: Nutriments): Promise<void>;
-  findIngredientsByBarcode(barcode: string): Promise<string[]>;
 }

--- a/src/infrastructure/openfoodfacts/off-api-adapter.test.ts
+++ b/src/infrastructure/openfoodfacts/off-api-adapter.test.ts
@@ -136,4 +136,60 @@ describe("OffApiAdapter: mappers", () => {
     const product = await adapter.findByBarcode("5000159484695");
     expect(product?.labels).toEqual(["organic", "gluten-free"]);
   });
+
+  it("mappt ingredients_text zu ingredientsList (comma-separated)", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 1,
+        product: { product_name: "Test", ingredients_text: "Zucker, Wasser, Salz" },
+      }),
+    } as Response);
+
+    const adapter = new OffApiAdapter();
+    const product = await adapter.findByBarcode("5000159484695");
+    expect(product?.ingredientsList).toEqual(["Zucker", "Wasser", "Salz"]);
+  });
+
+  it("mappt ingredients_text zu ingredientsList (newline-separated)", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 1,
+        product: { product_name: "Test", ingredients_text: "Zucker\nWasser\nSalz" },
+      }),
+    } as Response);
+
+    const adapter = new OffApiAdapter();
+    const product = await adapter.findByBarcode("5000159484695");
+    expect(product?.ingredientsList).toEqual(["Zucker", "Wasser", "Salz"]);
+  });
+
+  it("omits ingredientsList when ingredients_text is empty", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 1,
+        product: { product_name: "Test", ingredients_text: "" },
+      }),
+    } as Response);
+
+    const adapter = new OffApiAdapter();
+    const product = await adapter.findByBarcode("5000159484695");
+    expect(product?.ingredientsList).toBeUndefined();
+  });
+
+  it("omits ingredientsList when ingredients_text is missing", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 1,
+        product: { product_name: "Test" },
+      }),
+    } as Response);
+
+    const adapter = new OffApiAdapter();
+    const product = await adapter.findByBarcode("5000159484695");
+    expect(product?.ingredientsList).toBeUndefined();
+  });
 });

--- a/src/infrastructure/openfoodfacts/off-api-adapter.test.ts
+++ b/src/infrastructure/openfoodfacts/off-api-adapter.test.ts
@@ -165,6 +165,20 @@ describe("OffApiAdapter: mappers", () => {
     expect(product?.ingredientsList).toEqual(["Zucker", "Wasser", "Salz"]);
   });
 
+  it("mappt ingredients_text zu ingredientsList (semicolon-separated)", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 1,
+        product: { product_name: "Test", ingredients_text: "Zucker; Wasser; Salz" },
+      }),
+    } as Response);
+
+    const adapter = new OffApiAdapter();
+    const product = await adapter.findByBarcode("5000159484695");
+    expect(product?.ingredientsList).toEqual(["Zucker", "Wasser", "Salz"]);
+  });
+
   it("omits ingredientsList when ingredients_text is empty", async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,

--- a/src/infrastructure/openfoodfacts/off-api-adapter.ts
+++ b/src/infrastructure/openfoodfacts/off-api-adapter.ts
@@ -55,8 +55,4 @@ export class OffApiAdapter implements IProductRepository {
 
   // OFf API ist read-only — no-op
   async updateNutriments(_barcode: string, _nutriments: Nutriments): Promise<void> {}
-
-  async findIngredientsByBarcode(_barcode: string): Promise<string[]> {
-    return [];
-  }
 }

--- a/src/infrastructure/openfoodfacts/off-mappers.ts
+++ b/src/infrastructure/openfoodfacts/off-mappers.ts
@@ -15,6 +15,16 @@ function mapNutriments(off: OffNutriments | undefined): Nutriments {
   };
 }
 
+function parseIngredientsList(ingredientsText: string | undefined): string[] | undefined {
+  if (!ingredientsText) return undefined;
+  // Split by comma or newline, trim each, filter empty strings
+  const list = ingredientsText
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.length > 0 ? list : undefined;
+}
+
 export function mapOffProductToProduct(barcode: string, off: OffProduct): Product {
   const additives = off.additives_tags ?? off.additives ?? [];
   return {
@@ -27,6 +37,7 @@ export function mapOffProductToProduct(barcode: string, off: OffProduct): Produc
       ? off.labels.split(",").map((l) => l.trim()).filter(Boolean)
       : [],
     ingredients: off.ingredients_text ?? "",
+    ingredientsList: parseIngredientsList(off.ingredients_text),
     categories: off.categories
       ? off.categories.split(",").map((c) => c.trim()).filter(Boolean)
       : [],

--- a/src/infrastructure/openfoodfacts/off-mappers.ts
+++ b/src/infrastructure/openfoodfacts/off-mappers.ts
@@ -17,9 +17,9 @@ function mapNutriments(off: OffNutriments | undefined): Nutriments {
 
 function parseIngredientsList(ingredientsText: string | undefined): string[] | undefined {
   if (!ingredientsText) return undefined;
-  // Split by comma or newline, trim each, filter empty strings
+  // Split by comma, semicolon, or newline, trim each, filter empty strings
   const list = ingredientsText
-    .split(/[,\n]/)
+    .split(/[,;\n]/)
     .map((s) => s.trim())
     .filter(Boolean);
   return list.length > 0 ? list : undefined;

--- a/src/infrastructure/sqlite/sqlite-mappers.test.ts
+++ b/src/infrastructure/sqlite/sqlite-mappers.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { mapDbRowToProduct } from "./sqlite-mappers";
+import type { DbProductRow } from "./sqlite-client";
+
+describe("mapDbRowToProduct", () => {
+  const baseRow: DbProductRow = {
+    barcode: "1234567890123",
+    product_name: "Testprodukt",
+    brands: "Testmarke",
+    image_url: "http://example.com/img.jpg",
+    nutriments: null,
+    labels: null,
+    ingredients_text: "Zucker, Wasser",
+    categories: null,
+    additives_tags: null,
+  };
+
+  it("maps basic fields correctly", () => {
+    const result = mapDbRowToProduct(baseRow);
+    expect(result.barcode).toBe("1234567890123");
+    expect(result.name).toBe("Testprodukt");
+    expect(result.brand).toBe("Testmarke");
+    expect(result.imageUrl).toBe("http://example.com/img.jpg");
+  });
+
+  it("sets ingredientsList when provided", () => {
+    const ingredientsList = ["Zucker", "Wasser", "Salz"];
+    const result = mapDbRowToProduct(baseRow, ingredientsList);
+    expect(result.ingredientsList).toEqual(["Zucker", "Wasser", "Salz"]);
+  });
+
+  it("omits ingredientsList when not provided", () => {
+    const result = mapDbRowToProduct(baseRow);
+    expect(result.ingredientsList).toBeUndefined();
+  });
+
+  it("omits ingredientsList when empty array is provided", () => {
+    const result = mapDbRowToProduct(baseRow, []);
+    expect(result.ingredientsList).toBeUndefined();
+  });
+
+  it("handles null optional fields", () => {
+    const row: DbProductRow = {
+      ...baseRow,
+      brands: null,
+      image_url: null,
+      labels: null,
+      categories: null,
+      additives_tags: null,
+    };
+    const result = mapDbRowToProduct(row);
+    expect(result.brand).toBeUndefined();
+    expect(result.imageUrl).toBeUndefined();
+    expect(result.labels).toEqual([]);
+    expect(result.categories).toEqual([]);
+    expect(result.additives).toEqual([]);
+  });
+
+  it("splits comma-separated labels", () => {
+    const row: DbProductRow = { ...baseRow, labels: "bio, gluten-free" };
+    const result = mapDbRowToProduct(row);
+    expect(result.labels).toEqual(["bio", "gluten-free"]);
+  });
+
+  it("filters empty strings from labels", () => {
+    const row: DbProductRow = { ...baseRow, labels: "bio, , gluten-free" };
+    const result = mapDbRowToProduct(row);
+    expect(result.labels).toEqual(["bio", "gluten-free"]);
+  });
+
+  it("parses nutriments JSON correctly", () => {
+    const row: DbProductRow = {
+      ...baseRow,
+      nutriments: JSON.stringify({
+        "energy-kcal_100g": 540,
+        fat_100g: 29.7,
+        "saturated-fat_100g": 10.8,
+        sugars_100g: 56.8,
+        fiber_100g: 2.7,
+        proteins_100g: 5.41,
+        salt_100g: 0.1,
+      }),
+    };
+    const result = mapDbRowToProduct(row);
+    expect(result.nutriments.energyKcal).toBe(540);
+    expect(result.nutriments.fat).toBe(29.7);
+    expect(result.nutriments.saturatedFat).toBe(10.8);
+    expect(result.nutriments.sugars).toBe(56.8);
+    expect(result.nutriments.fiber).toBe(2.7);
+    expect(result.nutriments.protein).toBe(5.41);
+    expect(result.nutriments.salt).toBe(0.1);
+  });
+
+  it("returns empty nutriments when JSON is invalid", () => {
+    const row: DbProductRow = { ...baseRow, nutriments: "invalid json" };
+    const result = mapDbRowToProduct(row);
+    expect(result.nutriments).toEqual({});
+  });
+});

--- a/src/infrastructure/sqlite/sqlite-mappers.ts
+++ b/src/infrastructure/sqlite/sqlite-mappers.ts
@@ -20,8 +20,8 @@ function parseNutriments(json: string | null): Nutriments {
   }
 }
 
-export function mapDbRowToProduct(row: DbProductRow, ingredientsList?: string[] | number): Product {
-  const list = Array.isArray(ingredientsList) ? ingredientsList : undefined;
+export function mapDbRowToProduct(row: DbProductRow, ingredientsList?: string[]): Product {
+  const list = ingredientsList && ingredientsList.length > 0 ? ingredientsList : undefined;
   return {
     barcode: row.barcode,
     name: row.product_name ?? "",

--- a/src/infrastructure/sqlite/sqlite-mappers.ts
+++ b/src/infrastructure/sqlite/sqlite-mappers.ts
@@ -20,7 +20,8 @@ function parseNutriments(json: string | null): Nutriments {
   }
 }
 
-export function mapDbRowToProduct(row: DbProductRow): Product {
+export function mapDbRowToProduct(row: DbProductRow, ingredientsList?: string[] | number): Product {
+  const list = Array.isArray(ingredientsList) ? ingredientsList : undefined;
   return {
     barcode: row.barcode,
     name: row.product_name ?? "",
@@ -31,6 +32,7 @@ export function mapDbRowToProduct(row: DbProductRow): Product {
       ? row.labels.split(",").map((l) => l.trim()).filter(Boolean)
       : [],
     ingredients: row.ingredients_text ?? "",
+    ingredientsList: list,
     categories: row.categories
       ? row.categories.split(",").map((c) => c.trim()).filter(Boolean)
       : [],

--- a/src/infrastructure/sqlite/sqlite-product-repository.test.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.test.ts
@@ -88,6 +88,57 @@ describe("SqliteProductRepository", () => {
       );
       consoleSpy.mockRestore();
     });
+
+    it("populates ingredientsList from findIngredientsByBarcode", async () => {
+      const mockRow = {
+        barcode: "1234567890123",
+        product_name: "Testprodukt",
+        brands: "Testmarke",
+        image_url: null,
+        nutriments: null,
+        labels: null,
+        ingredients_text: "Zucker, Wasser, Salz",
+        categories: null,
+        additives_tags: null,
+      };
+      const ingredientsRows = [{ name: "Zucker" }, { name: "Wasser" }, { name: "Salz" }];
+      mockPrepare.mockReturnValueOnce({
+        get: vi.fn(() => mockRow),
+      }).mockReturnValueOnce({
+        all: vi.fn(() => ingredientsRows),
+      });
+
+      repo = new SqliteProductRepository();
+      const result = await repo.findByBarcode("1234567890123");
+
+      expect(result).not.toBeNull();
+      expect(result!.ingredientsList).toEqual(["Zucker", "Wasser", "Salz"]);
+    });
+
+    it("omits ingredientsList when findIngredientsByBarcode returns empty", async () => {
+      const mockRow = {
+        barcode: "1234567890123",
+        product_name: "Testprodukt",
+        brands: null,
+        image_url: null,
+        nutriments: null,
+        labels: null,
+        ingredients_text: "",
+        categories: null,
+        additives_tags: null,
+      };
+      mockPrepare.mockReturnValueOnce({
+        get: vi.fn(() => mockRow),
+      }).mockReturnValueOnce({
+        all: vi.fn(() => []),
+      });
+
+      repo = new SqliteProductRepository();
+      const result = await repo.findByBarcode("1234567890123");
+
+      expect(result).not.toBeNull();
+      expect(result!.ingredientsList).toBeUndefined();
+    });
   });
 
   describe("search", () => {

--- a/src/infrastructure/sqlite/sqlite-product-repository.test.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.test.ts
@@ -181,42 +181,4 @@ describe("SqliteProductRepository", () => {
       consoleSpy.mockRestore();
     });
   });
-
-  describe("findIngredientsByBarcode", () => {
-    it("returns ingredient names in position order", async () => {
-      const rows = [{ name: "zucker" }, { name: "wasser" }, { name: "salz" }];
-      mockPrepare.mockReturnValue({ all: vi.fn(() => rows) });
-
-      repo = new SqliteProductRepository();
-      const result = await repo.findIngredientsByBarcode("1234567890123");
-
-      expect(result).toEqual(["zucker", "wasser", "salz"]);
-    });
-
-    it("returns empty array when no ingredients found", async () => {
-      mockPrepare.mockReturnValue({ all: vi.fn(() => []) });
-
-      repo = new SqliteProductRepository();
-      const result = await repo.findIngredientsByBarcode("0000000000000");
-
-      expect(result).toEqual([]);
-    });
-
-    it("returns empty array and logs error when DB throws", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      mockPrepare.mockReturnValue({
-        all: vi.fn(() => { throw new Error("DB error"); }),
-      });
-
-      repo = new SqliteProductRepository();
-      const result = await repo.findIngredientsByBarcode("1234567890123");
-
-      expect(result).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("findIngredientsByBarcode"),
-        expect.any(Error)
-      );
-      consoleSpy.mockRestore();
-    });
-  });
 });

--- a/src/infrastructure/sqlite/sqlite-product-repository.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.ts
@@ -56,7 +56,7 @@ export class SqliteProductRepository implements IProductRepository {
         .get(barcode) as DbProductRow | undefined;
       if (!row) return null;
       const ingredientsList = await this.findIngredientsByBarcode(barcode);
-      return mapDbRowToProduct(row, ingredientsList.length > 0 ? ingredientsList : undefined);
+      return mapDbRowToProduct(row, ingredientsList);
     } catch (err) {
       console.error("[SqliteProductRepository] findByBarcode failed:", err);
       return null;

--- a/src/infrastructure/sqlite/sqlite-product-repository.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.ts
@@ -138,7 +138,7 @@ export class SqliteProductRepository implements IProductRepository {
       }
 
       return {
-        products: rows.map(mapDbRowToProduct),
+        products: rows.map((row) => mapDbRowToProduct(row)),
         total: count,
         page,
       };
@@ -148,7 +148,7 @@ export class SqliteProductRepository implements IProductRepository {
     }
   }
 
-  async findIngredientsByBarcode(barcode: string): Promise<string[]> {
+  private async findIngredientsByBarcode(barcode: string): Promise<string[]> {
     try {
       const rows = getDb()
         .prepare(

--- a/src/infrastructure/sqlite/sqlite-product-repository.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.ts
@@ -54,7 +54,9 @@ export class SqliteProductRepository implements IProductRepository {
       const row = getDb()
         .prepare("SELECT * FROM products WHERE barcode = ?")
         .get(barcode) as DbProductRow | undefined;
-      return row ? mapDbRowToProduct(row) : null;
+      if (!row) return null;
+      const ingredientsList = await this.findIngredientsByBarcode(barcode);
+      return mapDbRowToProduct(row, ingredientsList.length > 0 ? ingredientsList : undefined);
     } catch (err) {
       console.error("[SqliteProductRepository] findByBarcode failed:", err);
       return null;

--- a/tests/fixtures/products/vermeiden.json
+++ b/tests/fixtures/products/vermeiden.json
@@ -5,6 +5,7 @@
   "imageUrl": "https://images.openfoodfacts.org/images/products/000/980/089/5007/front_en.77.200.jpg",
   "labels": ["No gluten"],
   "ingredients": "sugar, palm oil, hazelnuts, skim milk, cocoa, lecithin as emulsifier (soy), vanillin: an artificial flavor,",
+  "ingredientsList": ["sugar", "palm oil", "hazelnuts", "skim milk", "cocoa", "lecithin as emulsifier (soy)", "vanillin: an artificial flavor"],
   "categories": ["en:spreads", "en:chocolate-spreads"],
   "additives": [],
   "nutriments": {


### PR DESCRIPTION
## Summary
- Add `ingredientsList?: string[]` to the `Product` domain type
- Populate `ingredientsList` in `SqliteProductRepository.findByBarcode()` via `findIngredientsByBarcode()`
- Populate `ingredientsList` in `OffApiAdapter` by parsing `ingredients_text` (comma/newline split)
- Display "Zutaten" section in `ScoreCard` with capitalized ingredients
- Show info message when no ingredients are stored (scoring may be incomplete)
- Show completeness disclaimer below ingredients list
- Add unit tests for both repositories
- Add E2E test for ingredients display

## Test plan
- [x] `npm run test:run` — 187 unit tests pass
- [x] `npm run test:e2e` — 84 E2E tests pass
- [x] `npm run lint` — zero errors
- [x] `npm run build` — succeeds

Closes #67