### PR TITLE
fix(search): remove OFF-API fallback from list search

### DIFF
--- a/src/app/api/products/search/route.ts
+++ b/src/app/api/products/search/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { unstable_cache } from "next/cache";
 import { SearchProductsUseCase } from "@/core/use-cases/search-products";
-import {
-  makePrimaryProductRepository,
-  makeFallbackProductRepository,
-} from "@/infrastructure/container";
+import { makePrimaryProductRepository } from "@/infrastructure/container";
 
 // Server-side page size — locked to 50. The client-supplied page_size param is
 // accepted for backward compatibility but ignored by the cached path so that all
@@ -17,10 +14,7 @@ let _useCase: SearchProductsUseCase | null = null;
 
 function getSearchUseCase(): SearchProductsUseCase {
   if (!_useCase) {
-    _useCase = new SearchProductsUseCase(
-      makePrimaryProductRepository(),
-      makeFallbackProductRepository()
-    );
+    _useCase = new SearchProductsUseCase(makePrimaryProductRepository());
   }
   return _useCase;
 }

--- a/src/core/use-cases/search-products.test.ts
+++ b/src/core/use-cases/search-products.test.ts
@@ -30,21 +30,14 @@ const mockResult: SearchResult = {
 
 describe("SearchProductsUseCase", () => {
   it("returns results from primary repo", async () => {
-    const useCase = new SearchProductsUseCase(makeRepo(mockResult), makeRepo(emptyResult));
+    const useCase = new SearchProductsUseCase(makeRepo(mockResult));
     const result = await useCase.execute({ terms: "test", page: 1, pageSize: 20 });
     expect(result.total).toBe(1);
     expect(result.products[0].name).toBe("Test Produkt");
   });
 
-  it("falls back to fallback when primary is empty", async () => {
-    const fallbackResult: SearchResult = { ...mockResult, total: 5 };
-    const useCase = new SearchProductsUseCase(makeRepo(emptyResult), makeRepo(fallbackResult));
-    const result = await useCase.execute({ terms: "test", page: 1, pageSize: 20 });
-    expect(result.total).toBe(5);
-  });
-
-  it("returns empty result when both repos are empty", async () => {
-    const useCase = new SearchProductsUseCase(makeRepo(emptyResult), makeRepo(emptyResult));
+  it("returns empty result when primary is empty (no fallback)", async () => {
+    const useCase = new SearchProductsUseCase(makeRepo(emptyResult));
     const result = await useCase.execute({ terms: "xyz", page: 1, pageSize: 20 });
     expect(result.products).toHaveLength(0);
     expect(result.total).toBe(0);
@@ -52,7 +45,7 @@ describe("SearchProductsUseCase", () => {
 
   it("passes query parameters correctly to primary repo", async () => {
     const primary = makeRepo(mockResult);
-    const useCase = new SearchProductsUseCase(primary, makeRepo(emptyResult));
+    const useCase = new SearchProductsUseCase(primary);
     await useCase.execute({ terms: "linsen", category: "vegetables", page: 2, pageSize: 10 });
     expect(primary.search).toHaveBeenCalledWith({
       terms: "linsen",

--- a/src/core/use-cases/search-products.test.ts
+++ b/src/core/use-cases/search-products.test.ts
@@ -54,4 +54,11 @@ describe("SearchProductsUseCase", () => {
       pageSize: 10,
     });
   });
+
+  it("calls primary.search exactly once", async () => {
+    const primary = makeRepo(mockResult);
+    const useCase = new SearchProductsUseCase(primary);
+    await useCase.execute({ terms: "test", page: 1, pageSize: 20 });
+    expect(primary.search).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/core/use-cases/search-products.ts
+++ b/src/core/use-cases/search-products.ts
@@ -2,14 +2,9 @@ import type { IProductRepository } from "../ports/product-repository";
 import type { SearchQuery, SearchResult } from "../domain/product";
 
 export class SearchProductsUseCase {
-  constructor(
-    private readonly primaryRepo: IProductRepository,
-    private readonly fallbackRepo: IProductRepository
-  ) {}
+  constructor(private readonly primaryRepo: IProductRepository) {}
 
   async execute(query: SearchQuery): Promise<SearchResult> {
-    const result = await this.primaryRepo.search(query);
-    if (result.total > 0) return result;
-    return this.fallbackRepo.search(query);
+    return this.primaryRepo.search(query);
   }
 }


### PR DESCRIPTION
## Summary

- Remove OFF-API fallback from `SearchProductsUseCase` — only SQLite is used for text search and category browsing
- `GetProductUseCase` (barcode lookup) retains its OFF-API fallback
- Updated tests to reflect single-repository architecture

## Test plan

- [x] `npm run test:run` — 232 tests pass
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — successful

Fixes #86