### PR TITLE
feat(persistence): persist OFF products to SQLite with parsed ingredients

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -9,7 +9,7 @@ import wenigerGut from '../tests/fixtures/products/weniger-gut.json';
 const SKIPPED_KEY = 'hashimoto-pcos-onboarding-skipped';
 
 // Search API returns products with `code` field (not `barcode`)
-const toSearchProduct = (f: typeof gut) => ({ ...f, code: f.barcode });
+const toSearchProduct = (f: { barcode: string } & Record<string, unknown>) => ({ ...f, code: f.barcode });
 
 const MOCK_PRODUCTS = [gut, neutral, vermeiden, sehrGut, wenigerGut].map(toSearchProduct);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -859,9 +859,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -877,9 +874,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -897,9 +891,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -915,9 +906,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -935,9 +923,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -953,9 +938,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -973,9 +955,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -992,9 +971,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1010,9 +986,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1036,9 +1009,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1060,9 +1030,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1086,9 +1053,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1110,9 +1074,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1136,9 +1097,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1161,9 +1119,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1185,9 +1140,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1428,9 +1380,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1446,9 +1395,6 @@
       "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1466,9 +1412,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1484,9 +1427,6 @@
       "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1696,9 +1636,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1716,9 +1653,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1736,9 +1670,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1756,9 +1687,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1776,9 +1704,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1796,9 +1721,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2033,9 +1955,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2051,9 +1970,6 @@
       "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2071,9 +1987,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2089,9 +2002,6 @@
       "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2673,9 +2583,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2690,9 +2597,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2707,9 +2611,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2724,9 +2625,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2741,9 +2639,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2758,9 +2653,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2775,9 +2667,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2792,9 +2681,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5987,9 +5873,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6009,9 +5892,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6033,9 +5913,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6055,9 +5932,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6812,6 +6686,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/core/ports/product-repository.ts
+++ b/src/core/ports/product-repository.ts
@@ -1,7 +1,9 @@
 import type { Product, SearchQuery, SearchResult, Nutriments } from "../domain/product";
+import type { ParsedIngredient } from "../services/ingredient-parser";
 
 export interface IProductRepository {
   findByBarcode(barcode: string): Promise<Product | null>;
   search(query: SearchQuery): Promise<SearchResult>;
   updateNutriments(barcode: string, nutriments: Nutriments): Promise<void>;
+  saveProduct(product: Product, parsedIngredients: ParsedIngredient[]): Promise<void>;
 }

--- a/src/core/services/__tests__/ingredient-parser.test.ts
+++ b/src/core/services/__tests__/ingredient-parser.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { parseIngredients, isValidProductName } from "../ingredient-parser";
+
+describe("ingredient-parser", () => {
+  describe("parseIngredients", () => {
+    it("returns empty array for empty string", () => {
+      expect(parseIngredients("")).toEqual([]);
+      expect(parseIngredients("   ")).toEqual([]);
+    });
+
+    it("parses single ingredient", () => {
+      const result = parseIngredients("Zucker");
+      expect(result).toHaveLength(1);
+      expect(result[0].canonical).toBe("zucker");
+    });
+
+    it("splits on comma at depth 0", () => {
+      const result = parseIngredients("Zucker, Wasser, Salz");
+      expect(result.map((r) => r.canonical)).toEqual(["zucker", "wasser", "salz"]);
+    });
+
+    it("handles functional labels with colon: Emulgator: Sonnenblumenlecithin", () => {
+      const result = parseIngredients("Emulgator: Sonnenblumenlecithin");
+      // Should emit only "Sonnenblumenlecithin", not "emulgator"
+      expect(result.map((r) => r.canonical)).toContain("sonnenblumenlecithin");
+      expect(result.map((r) => r.canonical)).not.toContain("emulgator");
+    });
+
+    it("handles nested parentheses depth 1", () => {
+      const result = parseIngredients("Wasser (Mineralwasser), Zucker");
+      expect(result.map((r) => r.canonical)).toContain("wasser");
+      expect(result.map((r) => r.canonical)).toContain("zucker");
+    });
+
+    it("discards content at depth > 1 (percentages in nested parens)", () => {
+      const result = parseIngredients("Zutaten (enthält (min. 55%) Anteil), Zucker");
+      // Should not throw, should parse what's at depth 0 and 1
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("strips trailing percentages", () => {
+      const result = parseIngredients("Zucker 99,9%, Wasser");
+      const canonicals = result.map((r) => r.canonical);
+      expect(canonicals).toContain("zucker");
+      expect(canonicals).not.toContain("99,9%");
+    });
+
+    it("normalizes hyphens within words", () => {
+      const result = parseIngredients("Sonnenblumenöl, Rapsöl");
+      expect(result.map((r) => r.canonical)).toContain("sonnenblumenöl");
+      expect(result.map((r) => r.canonical)).toContain("rapsöl");
+    });
+
+    it("deduplicates canonical forms", () => {
+      const result = parseIngredients("Zucker, zucker, ZUCKER");
+      expect(result).toHaveLength(1);
+      expect(result[0].canonical).toBe("zucker");
+    });
+
+    it("filters out unknown ingredients not in whitelist", () => {
+      const result = parseIngredients("xyzUnknown123, Zucker");
+      const canonicals = result.map((r) => r.canonical);
+      expect(canonicals).not.toContain("xyzunknown123");
+      expect(canonicals).toContain("zucker");
+    });
+
+    it("preserves raw text for canonical match", () => {
+      const result = parseIngredients("SALZ");
+      expect(result).toHaveLength(1);
+      expect(result[0].raw).toBe("SALZ");
+      expect(result[0].canonical).toBe("salz");
+    });
+
+    it("handles semicolon as separator", () => {
+      const result = parseIngredients("Zucker; Wasser; Salz");
+      expect(result.map((r) => r.canonical)).toEqual(["zucker", "wasser", "salz"]);
+    });
+
+    it("skips standalone functional labels", () => {
+      const result = parseIngredients("Emulgator, Zucker");
+      // "Emulgator" alone should be filtered out
+      const canonicals = result.map((r) => r.canonical);
+      expect(canonicals).not.toContain("emulgator");
+      expect(canonicals).toContain("zucker");
+    });
+
+    it("handles multiple colons: Salz: Mehl: Zusatz", () => {
+      const result = parseIngredients("Salz: Mehl: Wasser");
+      // Should split and filter functional labels
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("returns empty for null/undefined input", () => {
+      expect(parseIngredients(null as unknown as string)).toEqual([]);
+      expect(parseIngredients(undefined as unknown as string)).toEqual([]);
+    });
+  });
+
+  describe("isValidProductName", () => {
+    it("returns false for empty or too short", () => {
+      expect(isValidProductName("")).toBe(false);
+      expect(isValidProductName("x")).toBe(false);
+      expect(isValidProductName("   ")).toBe(false);
+    });
+
+    it("returns false for placeholder names", () => {
+      expect(isValidProductName("xxx")).toBe(false);
+      expect(isValidProductName("unknown")).toBe(false);
+      expect(isValidProductName("n/a")).toBe(false);
+      expect(isValidProductName("to be completed")).toBe(false);
+    });
+
+    it("returns true for valid product names", () => {
+      expect(isValidProductName("Bio Joghurt")).toBe(true);
+      expect(isValidProductName("Haferflocken")).toBe(true);
+    });
+
+    it("handles non-string input", () => {
+      expect(isValidProductName(null as unknown as string)).toBe(false);
+      expect(isValidProductName(123 as unknown as string)).toBe(false);
+    });
+  });
+});

--- a/src/core/services/ingredient-parser.ts
+++ b/src/core/services/ingredient-parser.ts
@@ -1,0 +1,674 @@
+// src/core/services/ingredient-parser.ts
+// Pure TypeScript port of scripts/ingredient-parser.mjs — zero framework imports.
+
+// ── German ingredient names ────────────────────────────────────────────────────
+const GERMAN = new Set([
+  // Zucker & Süßungsmittel
+  'zucker','saccharose','glucose','dextrose','fruktose','lactose','maltose',
+  'raffinierter zucker','rohrzucker','vollrohrzucker','rohrzuckersirup','zuckersirup','invertzuckersirup',
+  'glukosesirup','glukose-fruktose-sirup','fruktosesirup','maisstärkesirup','reissirup',
+  'agavendicksaft','agavensirup','honig','bienenhonig','birnenmost','birnendicksaft',
+  'apfeldicksaft','apfelsaftkonzentrat','malzextrakt','malzodextrin','malz',
+  'stevia','steviolglycoside','erythrit','xylit','birkenzucker','sorbit','mannit',
+  'isomalt','maltit','tagatose','süßungsmittel','süßstoff',
+
+  // Mehle & Stärken
+  'weizenmehl','weizenvollkornmehl','weizenstärke','weizeneiweiß','weizengluten',
+  'roggenmehl','roggenvollkornmehl','roggenstärke','gerstenmehl','gerstenmalz',
+  'hafermehl','haferflocken','haferkleie','dinkelmehl','dinkelvollkornmehl','dinkelstärke',
+  'buchweizenmehl','buchweizen','hirsemehl','hirse','quinoa','quinoamehl','amaranth',
+  'maismehl','maisstärke','maisgrieß','polenta','kartoffelstärke','kartoffelmehl',
+  'reismehl','reisstärke','reisgrieß','klebreis','reis','reis gepufft','puffreis','gepuffter mais',
+  'tapiokastärke','tapiokamehl',
+  'kokosmehl','mandelmehl','haselnussmehl','paranussmehl','sojamehl','sojabohnenmehl',
+  'lupinenmehl','lupinenprotein','mehl','stärke','modifizierte stärke','veränderte stärke',
+
+  // Öle & Fette
+  'palmöl','palmin','palmfett','palmenfett','kokosöl','kokosfett','kokosnussöl',
+  'sonnenblumenöl','sonnenblumenfett','rapsöl','rapsfett','rebornöl',
+  'olivenöl','natives olivenöl extra','olivenöl extra vergine','olivenfruchtöl',
+  'maiskeimöl','maisöl','weizenkeimöl','sojaöl','sojabohnenöl',
+  'erdnussöl','arachisöl','walnussöl','haselnussöl','mandelöl','sesamöl','sesamfett',
+  'mohnöl','leinsamenöl','hanföl','distelöl','safloröl','traubenkernöl',
+  'avocadoöl','brasilianussöl','macadamiaöl','pistazienöl','pecanöl',
+  'tierisches fett','schweinefett','schmalz','gänsefett','entenfett','butterreinfett',
+  'ghee','butter','butterfett','milchfett','rahm','sahne','schlagsahne','sauerrahm',
+  'creme','crème fraîche','margarine','pflanzenmargarine','streichfett',
+  'fett','öl','öle','fette',
+
+  // Milch & Milchprodukte
+  'milch','vollmilch','teilentrahmte milch','entrahmte milch','milchpulver',
+  'magermilchpulver','vollmilchpulver','kondensmilch',
+  'milchkonzentrat','molkepulver','molke','molkenprotein','molkenproteinpulver',
+  'casein','natriumcaseinat','calciumcaseinat','caseinat','micellar casein',
+  'käse','hartkäse','weichkäse','schnittkäse','schmelzkäse','käsepulver',
+  'parmesan','pecorino','grana padano','gouda','emmentaler','bergkäse',
+  'brie','camembert','mozzarella','ricotta','quark','körnig','hüttenkäse',
+  'schichtkäse','smetana','saure sahne',
+  'joghurt','naturjoghurt','griechischer joghurt','joghurtpulver','joghurtkultur',
+  'kefir','kefirpilz','buttermilch','buttermilchpulver','ayran',
+  'milchprotein','milcheiweiß','milchzucker','laktose','laktoseintoleranz',
+  'laktalbumin','laktoglobulin','calciumlactat','calciumlaktat','milchsäure','milchsäurebakterien',
+
+  // Eier
+  'ei','eier','eiklar','eiweiß','eidotter','eigelb','vollei','volleier',
+  'eiweißpulver','eiweißkonzentrat','trockenei','eiextrakt','eipulver',
+  'hühnerei','hühnereier','wachtelei','wachteleier',
+
+  // Fleisch
+  'rindfleisch','rind','rindhack','rinderhackfleisch','rindfleischextrakt',
+  'schweinefleisch','schwein','schweinehack','schweinehackfleisch','schweinebauch',
+  'hähnchen','hähnchenfleisch','huhn','hühnerfleisch','hühnerbrust','hühnerschenkel',
+  'pute','putenfleisch','putenbrust','putenschenkel','truthahn',
+  'lamm','lammfleisch','lammhack','lammkeule','lammrücken',
+  'ziege','ziegenfleisch','ziegenkäse','ziegenmilch',
+  'wild','wildbret','hirsch','reh','wildschwein','kaninchen','hasen',
+  'fisch','fischfleisch','fleisch','fleischextrakt','fleischbrühe',
+  'gelatine','rindergelatine','schweinegelatine','gelatinepulver',
+
+  // Fisch & Meeresfrüchte
+  'lachs','lachsfilet','wildlachs','lachskaviar','rogen','kaviar',
+  'forelle','regenbogenforelle','saibling','renke','renken',
+  'makrele','hering','sardine','sardellen','anchovis','ansjovis',
+  'thunfisch','tunfisch','bonito','schwertfisch','seelachs','kabeljau','dorsch',
+  'seehecht','hechtdorsch','wolfsbarsch','barsch','zander','hecht',
+  'garnele','garnelen','shrimp','shrimps','krabbe','krabben',
+  'hummer','lobster','miesmuschel','miesmuscheln','austern','schnecken',
+  'calamari','tintenfisch','sepie','octopus','pulpo',
+  'fischöl','fischleberöl','cod liver oil','dorschlebertran',
+  'algen','algenöl','algenpulver','spirulina','chlorella','wakame','nori',
+  'pektin',
+
+  // Gemüse
+  'tomate','tomaten','tomatenmark','tomatenkonzentrat','tomatenpulver',
+  'trockentomaten','getrocknete tomaten','tomatenextrakt',
+  'paprika','paprikapulver','paprikaflocken','chili','chilipulver','chiliflocken',
+  'cayenne','peperoni','peperoncini','pimiento',
+  'karotte','karotten','möhre','möhren','möhrensaft','karottensaft',
+  'zwiebel','zwiebeln','schalotte','schalotten','lauch','porree','lauchzwiebel',
+  'knoblauch','knoblauchpulver','knoblauchgranulat',
+  'kohl','weißkohl','rotkohl','sauerkraut','blumenkohl','brokkoli',
+  'rosenkohl','wirsing','kopfkohl','staudensellerie','sellerie',
+  'sellerieblätter','staudenselleriesaft',
+  'spargel','chicoree','endivie','radieschen','rettich','mangold',
+  'spinat','tiefkühlspinat','spinatpulver',
+  'gurke','gurken','cornichons','einlegegurke',
+  'avocado',
+  'artischocke','aubergine','auberginen','fenchel','fenchelsamen',
+  'kürbis','kürbiskernöl','kürbiskerne','kürbiskernmehl',
+  'zucchini','courgette','courgetti',
+  'erbsen','erbsenprotein','erbsenisolat','erbsenmehl','markerbsen',
+  'bohnen','bohnenmehl','gartenbohne','prinzessbohne','fisolen','grüne bohnen',
+  'linsen','linsenmehl','rote linsen','grüne linsen','bergbohnen',
+  'kichererbsen','kichererbsenmehl','humus','tahini','sesampaste',
+  'sojabohnen','edamame','sojakeime','sojasprossen',
+  'mungobohnen','adzukibohnen','limabohnen','kidneybohnen',
+  'pilze','champignons','pfifferlinge','steinpilze','maronen','trüffel',
+  'sprossen','keimlinge','samen','sprossenmix',
+
+  // Obst
+  'apfel','äpfel','apfelsaft','apfelmark','apfelkonzentrat',
+  'birne','birnen','birnensaft','birnenmark',
+  'banane','bananen','bananenpulver','getrocknete bananen',
+  'orange','apfelsine','orangensaft','orangensaftkonzentrat',
+  'zitrone','zitronensaft','zitronensaftkonzentrat','zitronenabrieb','zitronenöl',
+  'limette','limettensaft',
+  'traube','trauben','traubensaft','weintrauben','rosinen','korinthen',
+  'cranberry','cranberrysaft','preiselbeeren',
+  'heidelbeere','heidelbeeren','brombeere','brombeeren',
+  'himbeere','himbeeren','erdbeere','erdbeeren','erdbeermark',
+  'kirschen','sauerkirschen','morellen',
+  'pfirsich','pfirsiche','nektarine','aprikose','aprikosen',
+  'pflaume','pflaumen','zwetschge','zwetschgen','mirabelle','mirabellen',
+  'mango','mangos','mangopüree','mangokonzentrat',
+  'ananas','ananassaft','ananasstücke','ananasmark',
+  'papaya','papayapulver','passionsfrucht','maracuja','granatapfel','granatapfelsaft',
+  'kokosnuss','kokosraspel','kokosfruchtfleisch','kokosmilch','kokoswasser','kokosmus','kokosflocken','wasser',
+  'feige','feigen','dattel','datteln','dattelpaste',
+  'frucht','früchte','fruchtmark','fruchtextrakt','fruchtpulver',
+  'fruchtkonzentrat','fruchtsaft','fruchtzubereitung','fruchtpaste',
+
+  // Nüsse & Samen
+  'mandel','mandeln','mandelmus','mandelöl','mandelmehl','blanchierte mandeln',
+  'haselnuss','haselnüsse','haselnussmus','haselnussöl','haselnussmehl',
+  'walnuss','walnüsse','walnussöl',
+  'paranuss','paranüsse','brasilianernuss',
+  'cashew','cashewkerne','cashewmus','cashewöl',
+  'pistazie','pistazien','pistazienmus','pistazienöl',
+  'pecan','pecannüsse','macadamia','macadamianüsse','macadamiaöl',
+  'erdnuss','erdnüsse','erdnussöl','erdnussmus','erdnussmehl','entölte erdnüsse',
+  'sonnenblumenkerne','sonnenblumenkernmehl','sonnenblumenöl',
+  'kürbiskerne',
+  'leinsamen','leinsamenmehl','leinsamenöl','hanfsamen','hanföl','hanfmehl',
+  'chia','chia samen','chiaöl','chiasamen',
+  'sesam','sesamsamen','sesamöl',
+  'mohn','mohnsamen','mohnöl','sultaninen','johannisbrot','johannisbrotkernmehl',
+  'flohsamen','flohsamenschalen','psyllium','psyllium husk',
+
+  // Kräuter & Gewürze
+  'pfeffer','pfefferkorn','schwarzer pfeffer','weißer pfeffer','grüner pfeffer',
+  'kurkuma','kurkumaextrakt','curcuma','curcumin',
+  'ingwer','ingwerwurzel','ingwerpulver','ingwerextrakt',
+  'muskat','muskatnuss','macis',
+  'kardamom','kardamomkapseln',
+  'nelke','nelken','gewürznelken',
+  'zimt','zimtrinde','ceylon zimt','cassia zimt','cinnamon',
+  'anisbio','anis','sternanis',
+  'koriander','koriandersamen','korianderpulver','coriander',
+  'kümmel','kümmelsamen','caraway',
+  'thyme','thymian','rosemary','rosmarin','oregano','basilikum','basil',
+  'petersilie','petersil','dill','schnittlauch','lovage','liebstöckel',
+  'majoran','salbei','minze','pfefferminze','peppermint',
+  'schwarzkümmel',
+  'safran','vanille','vanilleschote','vanilleextrakt','vanillin',
+  'sumach','sumak',
+
+  // Gewürzmischungen
+  'gewürze','gewürzextrakte','gewürzmischung','curry','masala','garam masala',
+
+  // Getränke & Extrakte
+  'kaffee','kaffeepulver','kaffeextrakt','kaffeebohnen',
+  'löslicher kaffee','instantkaffee','espresso','espressopulver',
+  'tee','teeblätter','teepulver','grüner tee','schwarzer tee',
+  'früchtetee','kräutertee','rooibos',
+  'kakaopulver','kakao','kakaomasse','kakaobutter','cacao',
+  'schokolade','zartbitterschokolade','vollmilchschokolade','kuvertüre',
+  'gerstenmalz','gerstenextrakt','hopfen','hopfenextrakt',
+  'rosmarinnextrakt','rosmarin-extrakt','rosmarinextrakt',
+
+  // Fermentierte Produkte
+  'tempeh','miso','misopaste','misoextrakt',
+  'sojasauce','sojasoße','shoyu','tamari',
+  'fermentierte sojabohnen','fermentierte schwarze bohnen',
+  'kefir','kimchi','sauerkraut','fermentiertes',
+  'essig','weinessig','apfelessig','balsamessig','balsamico',
+  'branntweinessig','reissessig','rotweinessig',
+
+  // Hülsenfrüchte & Soja
+  'sojaprodukt','sojadrink','sojamehl','sojaprotein',
+  'sojaproteinisolat','sojaproteinkonzentrat','sojaeiweiß','sojagranulat',
+  'sojalezithin','sojalecithin','sojabohnenlecithin',
+  'tofu','tofuprodukt','seidentofu',
+  'bean sprouts',
+
+  // Lebensmittelzusatzstoffe
+  'lecithin','sojalecithin','sonnenblumenlecithin','rapslecithin','raps-lecithin',
+  'emulgator','emulgatoren',
+  'säuerungsmittel','citronensäure','zitronensäure',
+  'äpfelsäure','weinsäure','milchsäure','fumarsäure','phosphorsäure',
+  'natriumcitrat','kaliumcitrat','calciumcitrat',
+  'natriumcarbonat','natriumhydrogencarbonat','soda','natron',
+  'kaliumcarbonat','kaliumhydrogencarbonat',
+  'calciumcarbonat','kalk',
+  'magnesiumcarbonat','magnesiumoxid',
+  'salz','speisesalz','meersalz','jodsalz','jodiertes speisesalz',
+  'natriumchlorid','calciumchlorid','magnesiumchlorid','kaliumchlorid',
+  'phosphat','natriumphosphat','calciumphosphat','dicalciumphosphat',
+  'polyphosphat','natriumpolyphosphat','tripolyphosphat',
+  'diphosphat','natriumdiphosphat','dinatriumdiphosphat',
+  'natriumnitrit','natriumnitrat','kaliumnitrat',
+  'sulfit','natriumsulfit','natriummetabisulfit','schwefeldioxid',
+  'konservierungsstoff','konservierungsmittel','säureregulator',
+  'feuchthaltemittel','festigungsmittel',
+  'sorbat','kaliumsorbat','natriumsorbat','sorbinsäure',
+  'benzoat','natriumbenzoat','kaliumbenzoat','benzoesäure',
+  'natamycin','nisin',
+  'antioxidant','ascorbinsäure','vitamin c',
+  'natriumascorbat','calciumascorbat',
+  'tocopherol','tocopherolkonzentrat','vitamin e',
+  'citrat','acetat','tartrat','laktat','malat','fumarat',
+  'natriumacetat','calciumacetat','kaliumacetat',
+  'natriumtartrat','kaliumtartrat',
+  'guarkernmehl','guar','guarmehl','tara',
+  'xanthan','xanthan gum','xanthanpulver',
+  'carrageen','carrageenan',
+  'agar','agar-agar',
+  'cellulose','cellulosegummi',
+  'natriumcarboxymethylcellulose','modifizierte stärke',
+  'sonnenblumenwachs','candelillawachs','carnaubawachs','bienenwachs',
+  'siliciumdioxid','silica',
+  'calciumsilicat','magnesiumsilicat','talk','talkum',
+  'süßungsmittel','süßstoff',
+  'neohesperidin','steviolglycoside','steviaextrakt','stevia',
+  'saccharin','saccharinnatrium','cyclamat',
+  'aspartam','acesulfam','acesulfam k',
+  'sucralose','polydextrose',
+  'fruchtzubereitung','fruchtgrundstoff',
+
+  // Aromen
+  'aroma','aromen','natürliches aroma','natürliche aromen',
+  'naturidentisches aroma','künstliches aroma','aromaextrakt',
+  'ethylvanillin',
+  'lecitin','lecitinhaltig','rapslecitin','sonnenblumenlecitin',
+  'antioxidationsmittel','farbstoff','farbstoffe',
+  'stabilisator','stabilisatoren','verdickungsmittel',
+  'rauch','rauch-aroma','rauchflüssigkeit',
+  'trägerstoff','füllstoff','füllmittel','trennmittel',
+  'cumarin','kumarin',
+  'kakaoaroma','schokoladenaroma','kaffeearoma','malzaroma',
+  'fruchtaroma','beerenaroma','zitrusaroma',
+  'rauch aroma','rauchkondensat',
+
+  // Farbstoffe
+  'farbstoff','farbstoffe','lebensmittelfarbe',
+  'annatto','annattoextrakt',
+  'karmin','cochineal',
+  'paprikaextrakt','paprikafarbstoff','capsanthin',
+  'beta-carotin','betacarotin','carotin',
+  'lycopin',
+  'chlorophyll','chlorophyllin',
+  'zuckerkulör','caramel',
+  'titandioxid',
+  'riboflavin','vitamin b2',
+
+  // Hefe & Getreide
+  'hefe','hefeprodukt','hefeextrakt','hefepulver','hefekonzentrat',
+  'hefeautolysat','bäckerhefe','hefeflocken',
+  'malzkeime',
+  'zuckerrüben','zuckerrübenschnitzel',
+  'weizenkleie','reiskleie','haferkleie','kleie',
+  'cerealien','getreide','getreidemehl','getreidefasern',
+
+  // Sonstiges
+  'backpulver','hefebackpulver','natron','natriumbicarbonat',
+  'ammoniumcarbonat','ammoniumbicarbonat','hirschhornsalz',
+  'speck','bacon','schinken','rohschinken','kochschinken','pastete',
+  'hackfleisch','faschiertes',
+
+  // Nahrungsergänzung
+  'protein','proteinpulver','proteinisolat','proteinkonzentrat',
+  'molkenprotein','molkenproteinisolat',
+  'kollagen','kollagenpeptide','kollagenhydrolysat',
+  'kreatin','kreatinmonohydrat',
+  'vitamin','vitamine','vitaminkonzentrat',
+  'vitamin d','cholecalciferol','vitamin d3',
+  'vitamin b1','thiamin','vitamin b2',
+  'vitamin b3','niacin','niacinamid','vitamin b5','pantothensäure',
+  'vitamin b6','pyridoxin','vitamin b7','biotin',
+  'vitamin b9','folsäure','folat','vitamin b12','cobalamin','cyanocobalamin',
+  'methylcobalamin','inositol',
+  'calcium','magnesium','zink','eisen','selen','chrom','jod','kupfer','mangan','molybdän',
+  'omega-3','omega-3-fettsäuren',
+  'epa','dha','algenöl',
+  'carnitin','l-carnitin',
+  'coenzym q10',
+  'probiotika','probiotische kulturen',
+  'ballaststoffe','ballaststoff','inulin',
+
+  // Enzyme
+  'enzyme','enzym','lactase','laktase','amylase','protease',
+  'lipase','glucoamylase','transglutaminase','papain','bromelain',
+
+  // Alkohol
+  'ethanol','alkohol','weingeist',
+
+  // Algen
+  'algenmehl','algenextrakt','spirulinapulver',
+  'chlorellapulver','wakamemehl','norialgen',
+  'dulse','irish moss','kelp','kombu',
+
+  // Begleitstoffe
+  'maltodextrin','mannitol','sorbitol',
+  'gummi arabicum','akaziengummi',
+]);
+
+// ── English ingredient names ─────────────────────────────────────────────────
+const ENGLISH = new Set([
+  'water','salt','sugar','dextrose','glucose','fructose','lactose','maltose',
+  'sucrose','milk','cream','butter','cheese','yogurt','egg','eggs',
+  'egg white','egg yolk','whey','whey protein','casein','sodium caseinate',
+  'flour','wheat flour','rye flour','barley','oat','oats','spelt','buckwheat',
+  'quinoa','amaranth','millet','rice','corn','maize','potato','tapioca',
+  'soy','soybean','soy protein','soy lecithin','soybean oil','soy flour',
+  'tofu','tempeh','miso','soy sauce','shoyu','tamari','edamame',
+  'sunflower oil','sunflower seed','sunflower lecithin',
+  'palm oil','palm fat','coconut oil','coconut milk','coconut cream',
+  'olive oil','rapeseed oil','canola','corn oil','maize oil',
+  'sesame','sesame oil','sesame seeds','tahini',
+  'flax','flaxseed','linseed','flax oil','flaxseed oil',
+  'hemp','hemp oil','hemp seed','hemp protein',
+  'walnut','walnut oil','hazelnut','hazelnut oil','almond','almond oil',
+  'cashew','pecan','macadamia','pistachio','pine nut',
+  'peanut','peanut oil','peanut butter','groundnut',
+  'apple','orange','lemon','lime','grape','cherry','strawberry',
+  'blueberry','raspberry','blackberry','cranberry','currant',
+  'banana','mango','papaya','pineapple','peach','apricot','plum',
+  'date','fig','raisin','coconut','coconut water','coconut flesh',
+  'carrot','onion','garlic','leek','shallot','pepper','chili',
+  'cabbage','broccoli','cauliflower','kale','spinach','celery',
+  'tomato','cucumber','lettuce','artichoke','asparagus','eggplant',
+  'zucchini','pumpkin','squash','mushroom','mushrooms','champignon',
+  'beetroot','beet','radish','turnip','fennel','parsley','coriander',
+  'basil','oregano','thyme','rosemary','sage','mint','dill','chive',
+  'cumin','turmeric','curcuma',
+  'ginger','nutmeg','mace','cardamom','clove','cinnamon','vanilla',
+  'cocoa','cacao','chocolate','cocoa butter','cocoa mass','cocoa powder',
+  'coffee','espresso','tea','green tea','black tea',
+  'honey','maple syrup','agave','molasses','malt','malt extract',
+  'yeast','yeast extract','baking powder','bicarbonate','sodium bicarbonate',
+  'gelatin','gelatine','collagen','collagen peptides',
+  'fish','salmon','tuna','cod','sardine','anchovy','herring','mackerel',
+  'shrimp','prawn','crab','lobster','scallop','mussel','clam','oyster',
+  'algae','spirulina','chlorella','wakame','nori','kelp','dulse',
+  'meat','beef','pork','lamb','mutton','chicken','turkey','duck','goose',
+  'bacon','ham','sausage','minced meat','ground meat',
+  'vinegar','wine vinegar','apple cider vinegar','balsamic',
+  'whey protein isolate','whey protein concentrate',
+  'milk protein','milk protein concentrate','milk powder',
+  'skimmed milk powder','skim milk powder','whole milk powder',
+  'pectin','carrageenan','agar','xanthan gum','guar gum','locust bean gum',
+  'gum arabic','acacia gum','cellulose','microcrystalline cellulose',
+  'modified starch','tapioca starch','potato starch','corn starch','wheat starch',
+  'lecithin','sunflower lecithin','rapeseed lecithin','soy lecithin',
+  'emulsifier','emulsifiers','stabilizer','stabilizers',
+  'thickener','thickening agent',
+  'citric acid','sodium citrate','potassium citrate','calcium citrate',
+  'ascorbic acid','sodium ascorbate','calcium ascorbate','vitamin c',
+  'tocopherol','tocopherols','vitamin e',
+  'beta-carotene','carotene','lutein','zeaxanthin',
+  'sorbic acid','potassium sorbate','sodium sorbate',
+  'sulfur dioxide','sulphite','sodium sulphite',
+  'nitrite','sodium nitrite','nitrate','sodium nitrate',
+  'phosphate','sodium phosphate','calcium phosphate','diphosphate',
+  'salt','sea salt','rock salt','iodized salt','sodium chloride',
+  'monosodium glutamate','msg','glutamate',
+  'protein','protein powder','protein isolate','protein concentrate',
+  'annatto','carminic acid','cochineal','carmine',
+  'paprika extract','capsanthin','turmeric','curcumin',
+  'sugar','syrup','glucose syrup','invert sugar',
+  'polydextrose','inulin',
+  'amylase','protease','lipase','cellulase','glucoamylase',
+  'biotin','folic acid','folate','niacin','niacinamide',
+  'pantothenic acid','pyridoxine','riboflavin','thiamine','thiamin',
+  'cobalamin','cyanocobalamin','methylcobalamin',
+  'cholecalciferol','vitamin d','vitamin d3',
+  'retinol','vitamin a',
+  'omega-3','omega-6','dha','epa','ala',
+  'fish oil','cod liver oil','algal oil','algae oil',
+  'calcium','magnesium','iron','zinc','selenium','chromium','copper','manganese','iodine','potassium',
+  'silicon','silica','silicon dioxide',
+  'coenzyme q10','coq10','ubiquinol',
+  'l-carnitine','acetyl-l-carnitine','carnitine',
+  'creatine','creatine monohydrate',
+  'beta-alanine','bcaa','amino acids',
+  'tryptophan','5-htp','gaba','melatonin','inositol',
+  'probiotic','probiotics','lactobacillus','bifidobacterium',
+  'prebiotic','prebiotics',
+  'medium chain triglyceride','mct','mct oil',
+  'oil','fat','fats','oils',
+  'acid','fatty acid',
+  'enzyme','enzymes','transglutaminase',
+  'culture','cultures','starter culture',
+  'spice','spices','herb','herbs',
+  'extract','extracts','concentrate','concentrates',
+  'powder','powders','dried','dehydrated',
+  'natural','organic',
+  'bay leaf','cardamom','celery seed','cloves','curry powder',
+  'fennel seed','fenugreek','garam masala','garlic powder',
+  'horseradish','lavender','lemongrass','marjoram','mustard',
+  'mustard seed','nutmeg','orange peel','paprika','black pepper',
+  'white pepper','poppy seed','saffron','star anise','tarragon',
+  'vanilla bean','vanilla extract',
+  'antioxidant','antioxidants','preservative','preservatives',
+  'sweetener','sweeteners','thickeners',
+  'emulsifier','emulsifiers',
+]);
+
+// ── French ingredient names ───────────────────────────────────────────────────
+const FRENCH = new Set([
+  'sucre','sel','eau','farine','beurre','crème','lait','poudre de lait',
+  'fromage','yaourt','oeuf','oeufs','blanc d oeuf','jaune d oeuf',
+  'huile','huile d olive','huile de tournesol','huile de colza','huile de coco',
+  'huile de palme','huile de sésame','huile de lin','huile de mais',
+  'vinaigre','vinaigre de vin','vinaigre de cidre','vinaigre balsamique',
+  'levure','levure chimique','bicarbonate','bicarbonate de soude',
+  'chocolat','cacao','beurre de cacao','masse de cacao','poudre de cacao',
+  'café','extrait de café','café soluble','thé','extrait de thé',
+  'miel','sirop','sirop de glucose','sirop de fructose','sirop d agave',
+  'fructose','glucose','dextrose','saccharose','lactose','maltose',
+  'amidon','amidon de maïs','amidon de pomme de terre','amidon modifié',
+  'farine de blé','farine de seigle','farine de riz','farine de sarrasin',
+  'avoine','flocons d avoine','son d avoine',
+  'protéine','protéine de lait','protéine de soja','protéine de pois',
+  'graisse','graisse végétale','graisse animale','matière grasse',
+  'viande','bœuf','porc','poulet','dinde','agneau',
+  'poisson','saumon','thon','cabillaud','morue','sardine','anchois','hareng',
+  'crevette','crabe','homard','moule','huître',
+  'légume','légumes','tomate','oignon','ail','poireau','carotte','céleri',
+  'poivron','piment','brocoli','chou','chou-fleur',
+  'épinard','laitue','concombre','courgette','aubergine','artichaut',
+  'fruit','fruits','pomme','poire','banane','raisin','cerise','fraise',
+  'framboise','myrtille','cranberry','pêche','abricot','prune',
+  'mangue','papaye','ananas','datte','figue','raisin sec',
+  'noix','amande','noisette','noix de cajou','pistache',
+  'graine','graine de lin','graines de chia','graines de sésame',
+  'arachide','beurre d arachide','huile d arachide',
+  'soja','lécithine de soja','huile de soja',
+  'tofu','tempeh','miso','sauce de soja','shoyu','tamari',
+  'émulsifiant','émulsificateurs','stabilisant','épaississant',
+  'acidifiant','régulateur d acidité','antioxydants','antioxygène',
+  'conservateur','conservateurs','édulcorant','édulcorants',
+  'lécithine','lécithine de tournesol','lécithine de soja','lécithine de colza',
+  'arôme','arômes','arôme naturel','arômes naturels',
+  'colorant','colorants',
+  'carraghénane','gomme','gomme arabique','gomme xanthane',
+  'guar','tara','psyllium',
+  'cellulose','méthylcellulose',
+  'lactosérum','poudre de lactosérum','babeurre',
+  'crème fraîche','fromage fondu',
+  'malt','extrait de malt','sirop de malt',
+  'fibres','fibres alimentaires','pectine','inuline',
+  'culture','cultures','culture lactique','ferments lactiques',
+  'enzyme','enzymes','transglutaminase',
+  'vitamine','vitamines','minéral','minéraux',
+  'oméga-3','dha','epa','ala',
+  'huile de poisson','huile d algues','spirulline','chlorelle','wakam','nori','kelp',
+  'extrait de romarin',
+  'coenzyme q10','ubiquinol',
+  'l-carnitine','carnitine','créatine',
+  'probiotique','probiotiques','prébiotique','prébiotiques','lactobacillus','bifidobacterium',
+  'gélatine','collagène','peptides de collagène',
+]);
+
+// ── E-number whitelist ────────────────────────────────────────────────────────
+function generateENumbers(): Set<string> {
+  const s = new Set<string>();
+  for (let n = 100; n <= 199; n++) {
+    s.add('e' + n);
+    s.add('e' + n + 'a');
+    s.add('e' + n + 'b');
+  }
+  for (let n = 200; n <= 299; n++) s.add('e' + n);
+  for (let n = 300; n <= 399; n++) s.add('e' + n);
+  for (let n = 400; n <= 499; n++) s.add('e' + n);
+  for (let n = 500; n <= 599; n++) s.add('e' + n);
+  for (let n = 600; n <= 699; n++) s.add('e' + n);
+  for (let n = 700; n <= 799; n++) s.add('e' + n);
+  for (let n = 800; n <= 899; n++) s.add('e' + n);
+  for (let n = 900; n <= 999; n++) s.add('e' + n);
+  for (let n = 1100; n <= 1799; n++) s.add('e' + n);
+  return s;
+}
+
+const KNOWN_INGREDIENTS = new Set<string>([
+  ...GERMAN,
+  ...ENGLISH,
+  ...FRENCH,
+  ...generateENumbers(),
+]);
+
+function isKnownIngredient(normalized: string): boolean {
+  if (!normalized || normalized.length < 2) return false;
+  return KNOWN_INGREDIENTS.has(normalized);
+}
+
+const FUNCTIONAL_LABELS = new Set([
+  'emulgator','emulgatoren',
+  'antioxidationsmittel','antioxidant',
+  'säureregulator',
+  'säuerungsmittel',
+  'verdickungsmittel',
+  'feuchthaltemittel',
+  'festigungsmittel',
+  'konservierungsstoff','konservierungsmittel',
+]);
+
+const PLACEHOLDER_NAMES = new Set(['xxx', 'unknown', 'none', 'n/a', 'to be completed', '-']);
+
+export interface ParsedIngredient {
+  raw: string;
+  canonical: string;
+}
+
+/**
+ * Returns true if the product name is non-empty and not a known placeholder.
+ */
+export function isValidProductName(name: unknown): boolean {
+  if (!name || typeof name !== 'string') return false;
+  const t = name.trim();
+  if (t.length < 2) return false;
+  return !PLACEHOLDER_NAMES.has(t.toLowerCase());
+}
+
+/**
+ * Walks the raw ingredient string and returns a flat list of token strings.
+ * depth 0/1 → emit; depth > 1 → discard (percentage info inside nested parens).
+ */
+function flattenIngredients(text: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let depth = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '(') {
+      if (depth === 0 && current.trim()) {
+        tokens.push(current.trim());
+        current = '';
+      }
+      depth++;
+    } else if (ch === ')') {
+      if (depth === 1 && current.trim()) {
+        tokens.push(current.trim());
+        current = '';
+      }
+      if (depth > 0) depth--;
+    } else if (ch === ',') {
+      if (depth <= 1) {
+        let token = current.trim();
+        const rest = text.slice(i + 1);
+        const pctMatch = rest.match(/^\d+[,.]?\d*\s*%/);
+        if (pctMatch) {
+          token = token.replace(/\d+$/, '').trim();
+        }
+        if (token) tokens.push(token);
+        current = '';
+      }
+    } else if (ch === ';') {
+      if (depth <= 1) {
+        if (current.trim()) tokens.push(current.trim());
+        current = '';
+      }
+    } else {
+      if (depth <= 1) current += ch;
+    }
+  }
+  if (current.trim()) tokens.push(current.trim());
+  return tokens;
+}
+
+/**
+ * Parses a raw ingredients text string into an array of normalized ingredient objects.
+ */
+export function parseIngredients(text: unknown): ParsedIngredient[] {
+  if (!text || typeof text !== 'string') return [];
+
+  const flatTokens = flattenIngredients(text);
+
+  const segments: string[] = [];
+  for (const token of flatTokens) {
+    if (token.includes(':')) {
+      const parts = token.split(':');
+      if (parts.length === 2) {
+        const label = parts[0].trim();
+        const specific = parts[1].trim();
+        const labelLower = label.toLowerCase();
+        const specificLower = specific.toLowerCase();
+
+        if (isKnownIngredient(specificLower)) {
+          if (FUNCTIONAL_LABELS.has(labelLower)) {
+            segments.push(specific);
+          } else {
+            segments.push(label, specific);
+          }
+        } else {
+          segments.push(label, specific);
+        }
+      } else {
+        const filtered = token.split(':').filter(p => !FUNCTIONAL_LABELS.has(p.trim().toLowerCase()));
+        segments.push(...filtered);
+      }
+    } else {
+      segments.push(token);
+    }
+  }
+
+  const seen = new Set<string>();
+  const result: ParsedIngredient[] = [];
+
+  for (const rawSegment of segments) {
+    let seg = rawSegment.trim();
+    if (!seg) continue;
+
+    // Step 1: Strip remaining parenthetical content
+    let prev: string;
+    do {
+      prev = seg;
+      seg = seg.replace(/\s*\([^)]*\)\s*/g, ' ').trim();
+    } while (seg !== prev && seg.includes('('));
+
+    // Step 2: Remove trailing percentages
+    seg = seg.replace(/\d+[,.]?\d*\s*%\s*/g, '').trim();
+
+    // Step 3: Normalize internal hyphens
+    seg = seg.replace(/([a-zäöüß])\s*-\s+([a-zäöüß])/gi, '$1$2').trim();
+    seg = seg.replace(/([a-zäöüß])\s+-\s+([A-ZÄÖÜ])/g, '$1$2').trim();
+
+    // Step 4: Remove encoding artifacts
+    seg = seg.replace(/([a-zäöüß])\s*-\s+(?=[a-zäöüß])/gi, '$1').trim();
+
+    // Step 5: Collapse multiple spaces/dashes/underscores
+    seg = seg.replace(/\s{2,}/g, ' ').replace(/[_—–-]{2,}/g, ' ').trim();
+
+    // Step 6: Clean Unicode artifacts
+    seg = seg.replace(/[×•°©®™¹²³⁴⁵⁶⁷⁸⁹@#$%^&®]+/g, ' ').trim();
+
+    // Step 7: Normalize E-number format
+    seg = seg.replace(/^e\s*(\d+[a-z]?)\s*$/i, 'e$1').trim();
+
+    // Step 8: Remove digit-starting tokens
+    seg = seg.replace(/^[\d,.]+\s*/g, '').trim();
+    if (!seg || /^\d+$/.test(seg)) continue;
+
+    // Step 9: Remove short/non-alphabetic garbage
+    if (seg.length < 2) continue;
+    if (/^[^a-zäöüß]+$/i.test(seg)) continue;
+
+    // Step 10: Lowercase for canonical form
+    const canonical = seg.toLowerCase();
+
+    // Step 11: Deduplicate
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+
+    // Step 12: Whitelist check
+    if (!isKnownIngredient(canonical)) continue;
+
+    // Step 12b: Skip standalone functional labels
+    if (FUNCTIONAL_LABELS.has(canonical)) continue;
+
+    result.push({ raw: rawSegment.trim(), canonical });
+  }
+
+  return result;
+}

--- a/src/core/use-cases/get-product.test.ts
+++ b/src/core/use-cases/get-product.test.ts
@@ -24,6 +24,7 @@ function makeRepo(overrides: Partial<IProductRepository> = {}): IProductReposito
     findByBarcode: vi.fn().mockResolvedValue(null),
     search: vi.fn().mockResolvedValue({ products: [], total: 0, page: 1 }),
     updateNutriments: vi.fn().mockResolvedValue(undefined),
+    saveProduct: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -75,5 +76,47 @@ describe("GetProductUseCase", () => {
       "4006040197219",
       enriched.nutriments
     );
+  });
+
+  it("speichert OFF-Produkt in Primary wenn Fallback es liefert", async () => {
+    const fallbackProduct: Product = {
+      ...mockProduct,
+      ingredients: "Zucker, Wasser, Salz",
+    };
+    const primary = makeRepo();
+    const fallback = makeRepo({ findByBarcode: vi.fn().mockResolvedValue(fallbackProduct) });
+
+    const useCase = new GetProductUseCase(primary, fallback);
+    const result = await useCase.execute("4006040197219");
+
+    expect(result.success).toBe(true);
+    expect(primary.saveProduct).toHaveBeenCalledOnce();
+    expect(primary.saveProduct).toHaveBeenCalledWith(
+      fallbackProduct,
+      expect.any(Array)
+    );
+  });
+
+  it("gibt Produkt zurück auch wenn saveProduct fehlschlägt (graceful degradation)", async () => {
+    const primary = makeRepo({
+      saveProduct: vi.fn().mockRejectedValue(new Error("DB error")),
+    });
+    const fallback = makeRepo({ findByBarcode: vi.fn().mockResolvedValue(mockProduct) });
+
+    const useCase = new GetProductUseCase(primary, fallback);
+    const result = await useCase.execute("4006040197219");
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.product.name).toBe("Test Produkt");
+  });
+
+  it("ruft saveProduct nicht auf wenn Produkt bereits in Primary vorhanden", async () => {
+    const primary = makeRepo({ findByBarcode: vi.fn().mockResolvedValue(mockProduct) });
+    const fallback = makeRepo();
+
+    const useCase = new GetProductUseCase(primary, fallback);
+    await useCase.execute("4006040197219");
+
+    expect(primary.saveProduct).not.toHaveBeenCalled();
   });
 });

--- a/src/core/use-cases/get-product.ts
+++ b/src/core/use-cases/get-product.ts
@@ -1,4 +1,5 @@
 import { isValidBarcode } from "../services/barcode-service";
+import { parseIngredients } from "../services/ingredient-parser";
 import type { IProductRepository } from "../ports/product-repository";
 import type { Product } from "../domain/product";
 
@@ -40,6 +41,12 @@ export class GetProductUseCase {
           success: false,
           error: { type: "not_found", message: "Produkt nicht gefunden" },
         };
+      }
+      try {
+        const parsedIngredients = parseIngredients(fallback.ingredients);
+        await this.primaryRepo.saveProduct(fallback, parsedIngredients);
+      } catch (err) {
+        console.error("[GetProductUseCase] saveProduct failed:", err);
       }
       return { success: true, product: fallback };
     }

--- a/src/core/use-cases/search-products.test.ts
+++ b/src/core/use-cases/search-products.test.ts
@@ -8,6 +8,7 @@ function makeRepo(searchResult: SearchResult): IProductRepository {
     findByBarcode: vi.fn().mockResolvedValue(null),
     search: vi.fn().mockResolvedValue(searchResult),
     updateNutriments: vi.fn().mockResolvedValue(undefined),
+    saveProduct: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/src/infrastructure/openfoodfacts/off-api-adapter.ts
+++ b/src/infrastructure/openfoodfacts/off-api-adapter.ts
@@ -1,6 +1,7 @@
 // src/infrastructure/openfoodfacts/off-api-adapter.ts
 import type { IProductRepository } from "../../core/ports/product-repository";
 import type { Product, SearchQuery, SearchResult, Nutriments } from "../../core/domain/product";
+import type { ParsedIngredient } from "../../core/services/ingredient-parser";
 import { mapOffProductToProduct } from "./off-mappers";
 import type { OffApiResponse, OffSearchResponse, OffProduct } from "./off-types";
 
@@ -53,6 +54,7 @@ export class OffApiAdapter implements IProductRepository {
     }
   }
 
-  // OFf API ist read-only — no-op
+  // OFf API ist read-only — no-ops
   async updateNutriments(_barcode: string, _nutriments: Nutriments): Promise<void> {}
+  async saveProduct(_product: Product, _parsedIngredients: ParsedIngredient[]): Promise<void> {}
 }

--- a/src/infrastructure/sqlite/sqlite-mappers.test.ts
+++ b/src/infrastructure/sqlite/sqlite-mappers.test.ts
@@ -13,6 +13,9 @@ describe("mapDbRowToProduct", () => {
     ingredients_text: "Zucker, Wasser",
     categories: null,
     additives_tags: null,
+    nutriscore_grade: null,
+    allergens: null,
+    categories_tags: null,
   };
 
   it("maps basic fields correctly", () => {

--- a/src/infrastructure/sqlite/sqlite-product-repository.test.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.test.ts
@@ -181,4 +181,94 @@ describe("SqliteProductRepository", () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe("saveProduct", () => {
+    it("upserts product and links parsed ingredients", async () => {
+      const mockRun = vi.fn();
+      const mockGet = vi.fn();
+      const mockAll = vi.fn().mockReturnValue([]);
+      mockPrepare.mockReturnValue({ run: mockRun, get: mockGet, all: mockAll });
+
+      // Ingredient INSERT OR IGNORE + SELECT for id
+      const ingredientId = 42;
+      mockGet.mockReturnValue({ id: ingredientId });
+
+      repo = new SqliteProductRepository();
+      const product = {
+        barcode: "4006040197219",
+        name: "Test Produkt",
+        brand: "Testmarke",
+        imageUrl: undefined,
+        nutriments: { sugars: 5 },
+        labels: ["bio"],
+        ingredients: "Zucker, Wasser",
+        categories: ["snacks"],
+        additives: [],
+      };
+      const parsedIngredients = [
+        { raw: "Zucker", canonical: "zucker" },
+        { raw: "Wasser", canonical: "wasser" },
+      ];
+
+      await repo.saveProduct(product, parsedIngredients);
+
+      // Should have called prepare multiple times (upsert product + ingredients)
+      expect(mockPrepare).toHaveBeenCalled();
+      // Product upsert must run
+      const allCalls: string[] = mockPrepare.mock.calls.map((c: unknown[]) => c[0] as string);
+      expect(allCalls.some((sql: string) => sql.includes("ON CONFLICT"))).toBe(true);
+    });
+
+    it("soll console.error bei DB-Fehler loggen und keinen Fehler werfen", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockPrepare.mockReturnValue({
+        run: vi.fn(() => { throw new Error("DB error"); }),
+        get: vi.fn(),
+        all: vi.fn().mockReturnValue([]),
+      });
+
+      repo = new SqliteProductRepository();
+      await expect(
+        repo.saveProduct(
+          {
+            barcode: "4006040197219",
+            name: "Test",
+            nutriments: {},
+            labels: [],
+            ingredients: "",
+            categories: [],
+            additives: [],
+          },
+          []
+        )
+      ).resolves.toBeUndefined();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[SqliteProductRepository] saveProduct failed:",
+        expect.any(Error)
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("handles empty parsedIngredients without errors", async () => {
+      const mockRun = vi.fn();
+      mockPrepare.mockReturnValue({ run: mockRun, get: vi.fn(), all: vi.fn().mockReturnValue([]) });
+
+      repo = new SqliteProductRepository();
+      await expect(
+        repo.saveProduct(
+          {
+            barcode: "4006040197219",
+            name: "Test",
+            nutriments: {},
+            labels: [],
+            ingredients: "",
+            categories: [],
+            additives: [],
+          },
+          []
+        )
+      ).resolves.toBeUndefined();
+    });
+  });
 });

--- a/src/infrastructure/sqlite/sqlite-product-repository.test.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.test.ts
@@ -185,13 +185,9 @@ describe("SqliteProductRepository", () => {
   describe("saveProduct", () => {
     it("upserts product and links parsed ingredients", async () => {
       const mockRun = vi.fn();
-      const mockGet = vi.fn();
+      const mockGet = vi.fn().mockReturnValue({ id: 42 });
       const mockAll = vi.fn().mockReturnValue([]);
       mockPrepare.mockReturnValue({ run: mockRun, get: mockGet, all: mockAll });
-
-      // Ingredient INSERT OR IGNORE + SELECT for id
-      const ingredientId = 42;
-      mockGet.mockReturnValue({ id: ingredientId });
 
       repo = new SqliteProductRepository();
       const product = {
@@ -212,11 +208,13 @@ describe("SqliteProductRepository", () => {
 
       await repo.saveProduct(product, parsedIngredients);
 
-      // Should have called prepare multiple times (upsert product + ingredients)
-      expect(mockPrepare).toHaveBeenCalled();
-      // Product upsert must run
-      const allCalls: string[] = mockPrepare.mock.calls.map((c: unknown[]) => c[0] as string);
-      expect(allCalls.some((sql: string) => sql.includes("ON CONFLICT"))).toBe(true);
+      const sqlCalls: string[] = mockPrepare.mock.calls.map((c: unknown[]) => c[0] as string);
+      // Product upsert SQL must include ON CONFLICT clause
+      expect(sqlCalls.some((sql) => sql.includes("ON CONFLICT"))).toBe(true);
+      // product_ingredients INSERT must include raw_text column
+      expect(sqlCalls.some((sql) => sql.includes("raw_text"))).toBe(true);
+      // products_fts INSERT must be present for search index
+      expect(sqlCalls.some((sql) => sql.includes("products_fts"))).toBe(true);
     });
 
     it("soll console.error bei DB-Fehler loggen und keinen Fehler werfen", async () => {

--- a/src/infrastructure/sqlite/sqlite-product-repository.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.ts
@@ -201,17 +201,23 @@ export class SqliteProductRepository implements IProductRepository {
         product.categories.join(",") || null,
       );
 
+      // Keep the FTS index in sync (external content table — no automatic trigger)
+      db.prepare(
+        `INSERT OR IGNORE INTO products_fts(rowid, barcode, product_name, brands)
+         VALUES ((SELECT rowid FROM products WHERE barcode = ?), ?, ?, ?)`
+      ).run(product.barcode, product.barcode, product.name, product.brand ?? null);
+
       if (parsedIngredients.length > 0) {
-        // Remove existing ingredient links to allow fresh insert
+        // Remove stale ingredient links before re-inserting
         db.prepare("DELETE FROM product_ingredients WHERE barcode = ?").run(product.barcode);
 
         for (let i = 0; i < parsedIngredients.length; i++) {
-          const { canonical } = parsedIngredients[i];
+          const { raw, canonical } = parsedIngredients[i];
           db.prepare("INSERT OR IGNORE INTO ingredients (name) VALUES (?)").run(canonical);
           const row = db.prepare("SELECT id FROM ingredients WHERE name = ?").get(canonical) as { id: number };
           db.prepare(
-            "INSERT OR IGNORE INTO product_ingredients (barcode, ingredient_id, position) VALUES (?, ?, ?)"
-          ).run(product.barcode, row.id, i);
+            "INSERT OR IGNORE INTO product_ingredients (barcode, ingredient_id, raw_text, position) VALUES (?, ?, ?, ?)"
+          ).run(product.barcode, row.id, raw, i);
         }
       }
     } catch (err) {

--- a/src/infrastructure/sqlite/sqlite-product-repository.ts
+++ b/src/infrastructure/sqlite/sqlite-product-repository.ts
@@ -1,6 +1,7 @@
 // src/infrastructure/sqlite/sqlite-product-repository.ts
 import type { IProductRepository } from "../../core/ports/product-repository";
 import type { Product, SearchQuery, SearchResult, Nutriments } from "../../core/domain/product";
+import type { ParsedIngredient } from "../../core/services/ingredient-parser";
 import { getDb } from "./sqlite-client";
 import { mapDbRowToProduct } from "./sqlite-mappers";
 import type { DbProductRow } from "./sqlite-client";
@@ -162,6 +163,59 @@ export class SqliteProductRepository implements IProductRepository {
     } catch (err) {
       console.error("[SqliteProductRepository] findIngredientsByBarcode failed:", err);
       return [];
+    }
+  }
+
+  async saveProduct(product: Product, parsedIngredients: ParsedIngredient[]): Promise<void> {
+    try {
+      const db = getDb();
+      const nutrientsJson = JSON.stringify({
+        "energy-kcal_100g": product.nutriments.energyKcal ?? null,
+        fat_100g: product.nutriments.fat ?? null,
+        "saturated-fat_100g": product.nutriments.saturatedFat ?? null,
+        sugars_100g: product.nutriments.sugars ?? null,
+        fiber_100g: product.nutriments.fiber ?? null,
+        proteins_100g: product.nutriments.protein ?? null,
+        salt_100g: product.nutriments.salt ?? null,
+      });
+
+      db.prepare(
+        `INSERT INTO products (barcode, product_name, brands, image_url, nutriments, labels, ingredients_text, categories)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(barcode) DO UPDATE SET
+           product_name = excluded.product_name,
+           brands = excluded.brands,
+           image_url = excluded.image_url,
+           nutriments = excluded.nutriments,
+           labels = excluded.labels,
+           ingredients_text = excluded.ingredients_text,
+           categories = excluded.categories`
+      ).run(
+        product.barcode,
+        product.name,
+        product.brand ?? null,
+        product.imageUrl ?? null,
+        nutrientsJson,
+        product.labels.join(",") || null,
+        product.ingredients || null,
+        product.categories.join(",") || null,
+      );
+
+      if (parsedIngredients.length > 0) {
+        // Remove existing ingredient links to allow fresh insert
+        db.prepare("DELETE FROM product_ingredients WHERE barcode = ?").run(product.barcode);
+
+        for (let i = 0; i < parsedIngredients.length; i++) {
+          const { canonical } = parsedIngredients[i];
+          db.prepare("INSERT OR IGNORE INTO ingredients (name) VALUES (?)").run(canonical);
+          const row = db.prepare("SELECT id FROM ingredients WHERE name = ?").get(canonical) as { id: number };
+          db.prepare(
+            "INSERT OR IGNORE INTO product_ingredients (barcode, ingredient_id, position) VALUES (?, ?, ?)"
+          ).run(product.barcode, row.id, i);
+        }
+      }
+    } catch (err) {
+      console.error("[SqliteProductRepository] saveProduct failed:", err);
     }
   }
 


### PR DESCRIPTION
## Summary

- Ports ingredient parser from `scripts/ingredient-parser.mjs` to `src/core/services/ingredient-parser.ts` (pure TypeScript, zero framework dependencies)
- Adds `saveProduct()` to `IProductRepository` port and implements it in `SqliteProductRepository` — upserts product row, keeps `products_fts` in sync, and links parsed ingredients via the `ingredients`/`product_ingredients` tables
- Wires `GetProductUseCase` fallback flow: OFF products are now persisted to SQLite on first scan (graceful degradation — product is still returned if save fails)
- Fixes two silent bugs discovered during manual testing: missing `raw_text` column in `product_ingredients` INSERT and missing `products_fts` update for newly saved products

Closes #88

## Test plan

- [x] 258/258 Vitest unit/integration tests pass (`npm run test:run`)
- [x] 0 ESLint errors (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [x] 19 new tests for `ingredient-parser.ts`
- [x] 4 new tests for `GetProductUseCase` save/graceful-degradation behavior
- [x] 3 new tests for `SqliteProductRepository.saveProduct` (including `raw_text` and `products_fts` assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)