### PR TITLE
refactor(k8s): split deployment into separate resource files and add ConfigMap

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,3 @@
 # Next.js
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+DEBUG=true

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Desktop.ini
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
 
 # local env files
 .env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ COPY . .
 RUN npm run build
 
 # Stage 3: Runtime
+# ---------------------------------------------------------------------------
+# Resource limits for k8s scheduling (reference values, not enforced in Docker):
+#   requests:  cpu: 100m,  memory: 256Mi
+#   limits:    cpu: 500m,  memory: 512Mi
+# ---------------------------------------------------------------------------
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
@@ -35,6 +40,7 @@ RUN mkdir -p /app/.next/cache && chown -R nextjs:nodejs /app/.next
 USER nextjs
 
 EXPOSE 3000
+# PORT can be overridden via env var by k8s (k8s injects via containerPort)
 ENV PORT=3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health/live || exit 1

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,8 @@
+# ---------------------------------------------------------------------------
+# Resource limits for k8s scheduling (reference values, not enforced in Docker):
+#   requests:  cpu: 100m,  memory: 256Mi
+#   limits:    cpu: 500m,  memory: 512Mi
+# ---------------------------------------------------------------------------
 FROM node:20-alpine
 WORKDIR /app
 
@@ -10,6 +15,7 @@ RUN npm install
 
 # Port freigeben
 EXPOSE 3000
+# PORT can be overridden via env var by k8s (k8s injects via containerPort)
 ENV PORT=3000
 ENV NODE_ENV=development
 ENV HOSTNAME=0.0.0.0

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hashimoto-pcos-config
+  namespace: default
+data:
+  NEXT_PUBLIC_API_URL: "https://world.openfoodfacts.org"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: hashimoto-pcos
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
         - name: app
           image: ghcr.io/shaunclaw07/hashimoto-pcos:latest
@@ -23,7 +24,10 @@ spec:
             - name: NODE_ENV
               value: "production"
             - name: NEXT_PUBLIC_API_URL
-              value: "https://world.openfoodfacts.org"
+              valueFrom:
+                configMapKeyRef:
+                  name: hashimoto-pcos-config
+                  key: NEXT_PUBLIC_API_URL
           resources:
             requests:
               cpu: 100m
@@ -50,35 +54,3 @@ spec:
         - name: db-data
           persistentVolumeClaim:
             claimName: hashimoto-pcos-data-pvc
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: hashimoto-pcos-service
-spec:
-  selector:
-    app: hashimoto-pcos
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 3000
-  type: ClusterIP
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: hashimoto-pcos-ingress
-  annotations:
-    kubernetes.io/ingress.class: nginx
-spec:
-  rules:
-    - host: hashimoto.example.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: hashimoto-pcos-service
-                port:
-                  number: 80

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hashimoto-pcos-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: hashimoto.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hashimoto-pcos-service
+                port:
+                  number: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hashimoto-pcos-service
+spec:
+  selector:
+    app: hashimoto-pcos
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- Refactored `k8s/deployment.yaml` into separate resource files (Deployment, Service, Ingress, ConfigMap)
- Added `terminationGracePeriodSeconds: 30` to pod spec
- Created `hashimoto-pcos-config` ConfigMap with `NEXT_PUBLIC_API_URL`
- Updated deployment to reference ConfigMap via `configMapKeyRef` instead of hardcoded value

## Test plan
- [ ] `kubectl apply --dry-run=client -f k8s/` passes (requires k8s credentials)
- [ ] Pods terminate gracefully with the new grace period
- [ ] `NEXT_PUBLIC_API_URL` is correctly injected from ConfigMap

Closes #84