### PR TITLE
feat(docker): auto-initialize database on first container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,14 @@ COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Copy node_modules needed for database initialization scripts
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+
+# Copy scripts for database initialization (needed by entrypoint)
+COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
+COPY --from=builder --chown=nextjs:nodejs /app/data ./data
+COPY --from=builder --chown=nextjs:nodejs /app/package*.json ./
+
 # Create cache directory with correct ownership for Next.js runtime writes
 RUN mkdir -p /app/.next/cache && chown -R nextjs:nodejs /app/.next
 
@@ -45,4 +53,5 @@ ENV PORT=3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health/live || exit 1
 
+ENTRYPOINT ["node", "scripts/docker-entrypoint.mjs"]
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+# Default UID/GID for DB file ownership (matches nextjs user)
+ENV DB_FILE_UID=1001
+ENV DB_FILE_GID=1001
+
 # Non-root user
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
@@ -39,6 +43,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 
 # Copy scripts for database initialization (needed by entrypoint)
 COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
+# Intentional: data dir is empty at build time; entrypoint creates DB if no volume data exists.
+# This COPY ensures the directory exists with correct ownership for the non-root user.
 COPY --from=builder --chown=nextjs:nodejs /app/data ./data
 COPY --from=builder --chown=nextjs:nodejs /app/package*.json ./
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,5 +20,9 @@ ENV PORT=3000
 ENV NODE_ENV=development
 ENV HOSTNAME=0.0.0.0
 
+# Default UID/GID for DB file ownership
+ENV DB_FILE_UID=1001
+ENV DB_FILE_GID=1001
+
 ENTRYPOINT ["node", "scripts/docker-entrypoint.mjs"]
 CMD ["npm", "run", "dev"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,5 +20,5 @@ ENV PORT=3000
 ENV NODE_ENV=development
 ENV HOSTNAME=0.0.0.0
 
-# Dev-Server starten
+ENTRYPOINT ["node", "scripts/docker-entrypoint.mjs"]
 CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+    image: hashimoto-pcos:dev
+    container_name: hashimoto-app
     ports:
       - "3000:3000"
     environment:

--- a/scripts/build-db.mjs
+++ b/scripts/build-db.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { parseIngredients, isValidProductName } from './ingredient-parser.mjs';
 import { KNOWN_INGREDIENTS } from './ingredient-data.mjs';
+import { createSchema } from './create-schema.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isMinimal = process.argv.includes('--minimal');
@@ -55,51 +56,6 @@ function parseNutriments(r) {
     if (val !== null) count++;
   }
   return { values, count };
-}
-
-/**
- * Creates the database schema (tables, FTS index, relations).
- * Reusable for both full and minimal builds.
- * @param {Database} db - better-sqlite3 database instance
- */
-export function createSchema(db) {
-  db.exec(`
-    CREATE TABLE products (
-      barcode          TEXT PRIMARY KEY,
-      product_name     TEXT NOT NULL,
-      brands           TEXT,
-      image_url        TEXT,
-      nutriscore_grade TEXT,
-      ingredients_text TEXT,
-      allergens        TEXT,
-      additives_tags   TEXT,
-      nutriments       TEXT,
-      categories       TEXT,
-      categories_tags  TEXT,
-      labels           TEXT
-    );
-    CREATE VIRTUAL TABLE products_fts USING fts5(
-      barcode       UNINDEXED,
-      product_name,
-      brands,
-      content='products',
-      content_rowid='rowid'
-    );
-    CREATE TABLE ingredients (
-      id        INTEGER PRIMARY KEY AUTOINCREMENT,
-      name      TEXT NOT NULL UNIQUE
-    );
-    CREATE TABLE product_ingredients (
-      barcode        TEXT NOT NULL,
-      ingredient_id  INTEGER NOT NULL,
-      raw_text       TEXT NOT NULL,
-      position       INTEGER NOT NULL,
-      FOREIGN KEY (barcode) REFERENCES products(barcode) ON DELETE CASCADE,
-      FOREIGN KEY (ingredient_id) REFERENCES ingredients(id) ON DELETE CASCADE,
-      PRIMARY KEY (barcode, position),
-      UNIQUE (barcode, ingredient_id)
-    );
-  `);
 }
 
 // ── CLI Execution ──────────────────────────────────────────────────────────────

--- a/scripts/build-db.test.mjs
+++ b/scripts/build-db.test.mjs
@@ -3,7 +3,7 @@ import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { createSchema } from './build-db.mjs';
+import { createSchema } from './create-schema.mjs';
 import { KNOWN_INGREDIENTS } from './ingredient-data.mjs';
 
 describe('build-db.mjs — createSchema', () => {

--- a/scripts/create-schema.mjs
+++ b/scripts/create-schema.mjs
@@ -1,0 +1,56 @@
+// scripts/create-schema.mjs
+// Shared database schema definition used by build-db.mjs and init-minimal-db.mjs
+// Centralized here to prevent schema drift between build tools.
+
+/**
+ * SQL to create all database tables, indexes, and FTS virtual table.
+ * Must be kept in sync with src/infrastructure/sqlite/sqlite-schema.ts
+ */
+export const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS products (
+  barcode          TEXT PRIMARY KEY,
+  product_name     TEXT NOT NULL,
+  brands           TEXT,
+  image_url        TEXT,
+  nutriscore_grade TEXT,
+  ingredients_text TEXT,
+  allergens        TEXT,
+  additives_tags   TEXT,
+  nutriments       TEXT,
+  categories       TEXT,
+  categories_tags  TEXT,
+  labels           TEXT
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS products_fts USING fts5(
+  barcode       UNINDEXED,
+  product_name,
+  brands,
+  content='products',
+  content_rowid='rowid'
+);
+CREATE TABLE IF NOT EXISTS ingredients (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  name      TEXT NOT NULL UNIQUE
+);
+CREATE TABLE IF NOT EXISTS product_ingredients (
+  barcode        TEXT NOT NULL,
+  ingredient_id  INTEGER NOT NULL,
+  raw_text       TEXT NOT NULL,
+  position       INTEGER NOT NULL,
+  FOREIGN KEY (barcode) REFERENCES products(barcode) ON DELETE CASCADE,
+  FOREIGN KEY (ingredient_id) REFERENCES ingredients(id) ON DELETE CASCADE,
+  PRIMARY KEY (barcode, position),
+  UNIQUE (barcode, ingredient_id)
+);
+`;
+
+/**
+ * Creates all database tables (schema) for the products database.
+ * Idempotent — uses CREATE TABLE IF NOT EXISTS so it is safe to call
+ * on an already-initialized database.
+ *
+ * @param {Database} db - better-sqlite3 database instance
+ */
+export function createSchema(db) {
+  db.exec(SCHEMA_SQL);
+}

--- a/scripts/docker-entrypoint.mjs
+++ b/scripts/docker-entrypoint.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// scripts/docker-entrypoint.mjs
+// Entrypoint for both dev and production containers.
+// Creates a minimal database if none exists.
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = process.env.DB_PATH || path.join(process.cwd(), 'data', 'products.db');
+
+async function initDatabase() {
+  const dataDir = path.dirname(DB_PATH);
+
+  // Ensure data directory exists
+  if (!fs.existsSync(dataDir)) {
+    console.log(`[entrypoint] Creating data directory: ${dataDir}`);
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+
+  // Create minimal database if missing
+  if (!fs.existsSync(DB_PATH)) {
+    console.log(`[entrypoint] No database found at ${DB_PATH}`);
+    console.log('[entrypoint] Creating minimal database with schema and ingredients...');
+
+    const initScript = path.join(__dirname, 'init-minimal-db.mjs');
+
+    await new Promise((resolve, reject) => {
+      const child = spawn('node', [initScript], {
+        stdio: 'inherit',
+        env: { ...process.env, DB_PATH }
+      });
+
+      child.on('close', (code) => {
+        if (code === 0) {
+          console.log('[entrypoint] Database initialized successfully');
+          resolve();
+        } else {
+          reject(new Error(`init-minimal-db.mjs exited with code ${code}`));
+        }
+      });
+
+      child.on('error', reject);
+    });
+  } else {
+    console.log(`[entrypoint] Database found at ${DB_PATH}`);
+  }
+}
+
+async function main() {
+  try {
+    await initDatabase();
+  } catch (err) {
+    console.error('[entrypoint] Database initialization failed:', err.message);
+    process.exit(1);
+  }
+
+  // Execute the main command (CMD from Dockerfile or override)
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error('[entrypoint] No command specified');
+    process.exit(1);
+  }
+
+  console.log(`[entrypoint] Starting: ${args.join(' ')}`);
+
+  const child = spawn(args[0], args.slice(1), {
+    stdio: 'inherit',
+    env: process.env
+  });
+
+  child.on('close', (code) => {
+    process.exit(code ?? 0);
+  });
+}
+
+main();

--- a/scripts/init-minimal-db.mjs
+++ b/scripts/init-minimal-db.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// scripts/init-minimal-db.mjs
+// Minimal database initialization without external dependencies.
+// Only requires better-sqlite3 (which is a production dependency).
+
+import Database from 'better-sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import { KNOWN_INGREDIENTS } from './ingredient-data.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '..', 'data', 'products.db');
+
+/**
+ * Creates the database schema (tables, FTS index, relations).
+ */
+function createSchema(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS products (
+      barcode          TEXT PRIMARY KEY,
+      product_name     TEXT NOT NULL,
+      brands           TEXT,
+      image_url        TEXT,
+      nutriscore_grade TEXT,
+      ingredients_text TEXT,
+      allergens        TEXT,
+      additives_tags   TEXT,
+      nutriments       TEXT,
+      categories       TEXT,
+      categories_tags  TEXT,
+      labels           TEXT
+    );
+    CREATE VIRTUAL TABLE IF NOT EXISTS products_fts USING fts5(
+      barcode       UNINDEXED,
+      product_name,
+      brands,
+      content='products',
+      content_rowid='rowid'
+    );
+    CREATE TABLE IF NOT EXISTS ingredients (
+      id        INTEGER PRIMARY KEY AUTOINCREMENT,
+      name      TEXT NOT NULL UNIQUE
+    );
+    CREATE TABLE IF NOT EXISTS product_ingredients (
+      barcode        TEXT NOT NULL,
+      ingredient_id  INTEGER NOT NULL,
+      raw_text       TEXT NOT NULL,
+      position       INTEGER NOT NULL,
+      FOREIGN KEY (barcode) REFERENCES products(barcode) ON DELETE CASCADE,
+      FOREIGN KEY (ingredient_id) REFERENCES ingredients(id) ON DELETE CASCADE,
+      PRIMARY KEY (barcode, position),
+      UNIQUE (barcode, ingredient_id)
+    );
+  `);
+}
+
+// Main
+const dataDir = path.dirname(DB_PATH);
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+
+if (fs.existsSync(DB_PATH)) {
+  console.log('[init-minimal-db] Database already exists, skipping initialization.');
+  process.exit(0);
+}
+
+console.log('[init-minimal-db] Creating minimal database...');
+
+const db = new Database(DB_PATH);
+db.pragma('journal_mode = WAL');
+db.pragma('synchronous = NORMAL');
+
+createSchema(db);
+
+// Import all known ingredients
+const stmtUpsert = db.prepare('INSERT OR IGNORE INTO ingredients(name) VALUES (?)');
+const insertIngredients = db.transaction(() => {
+  for (const name of KNOWN_INGREDIENTS) {
+    stmtUpsert.run(name);
+  }
+});
+insertIngredients();
+
+db.close();
+
+console.log(`[init-minimal-db] Done! Database created at ${DB_PATH}`);
+console.log(`[init-minimal-db] Ingredients imported: ${KNOWN_INGREDIENTS.size}`);

--- a/scripts/init-minimal-db.mjs
+++ b/scripts/init-minimal-db.mjs
@@ -8,52 +8,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import { KNOWN_INGREDIENTS } from './ingredient-data.mjs';
+import { createSchema } from './create-schema.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DB_PATH = process.env.DB_PATH || path.join(__dirname, '..', 'data', 'products.db');
-
-/**
- * Creates the database schema (tables, FTS index, relations).
- */
-function createSchema(db) {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS products (
-      barcode          TEXT PRIMARY KEY,
-      product_name     TEXT NOT NULL,
-      brands           TEXT,
-      image_url        TEXT,
-      nutriscore_grade TEXT,
-      ingredients_text TEXT,
-      allergens        TEXT,
-      additives_tags   TEXT,
-      nutriments       TEXT,
-      categories       TEXT,
-      categories_tags  TEXT,
-      labels           TEXT
-    );
-    CREATE VIRTUAL TABLE IF NOT EXISTS products_fts USING fts5(
-      barcode       UNINDEXED,
-      product_name,
-      brands,
-      content='products',
-      content_rowid='rowid'
-    );
-    CREATE TABLE IF NOT EXISTS ingredients (
-      id        INTEGER PRIMARY KEY AUTOINCREMENT,
-      name      TEXT NOT NULL UNIQUE
-    );
-    CREATE TABLE IF NOT EXISTS product_ingredients (
-      barcode        TEXT NOT NULL,
-      ingredient_id  INTEGER NOT NULL,
-      raw_text       TEXT NOT NULL,
-      position       INTEGER NOT NULL,
-      FOREIGN KEY (barcode) REFERENCES products(barcode) ON DELETE CASCADE,
-      FOREIGN KEY (ingredient_id) REFERENCES ingredients(id) ON DELETE CASCADE,
-      PRIMARY KEY (barcode, position),
-      UNIQUE (barcode, ingredient_id)
-    );
-  `);
-}
 
 // Main
 const dataDir = path.dirname(DB_PATH);
@@ -84,6 +42,18 @@ const insertIngredients = db.transaction(() => {
 insertIngredients();
 
 db.close();
+
+// Set ownership to match runtime user (nextjs: 1001:1001)
+// This ensures the nextjs user can write to the DB
+// May fail on some filesystems (e.g., Windows volumes), so we catch and warn
+try {
+  const uid = process.env.DB_FILE_UID ? parseInt(process.env.DB_FILE_UID) : 1001;
+  const gid = process.env.DB_FILE_GID ? parseInt(process.env.DB_FILE_GID) : 1001;
+  fs.chownSync(DB_PATH, uid, gid);
+} catch (err) {
+  // chown may fail on filesystem that doesn't support it (e.g., some volume types)
+  console.warn('[init-minimal-db] chown skipped:', err.message);
+}
 
 console.log(`[init-minimal-db] Done! Database created at ${DB_PATH}`);
 console.log(`[init-minimal-db] Ingredients imported: ${KNOWN_INGREDIENTS.size}`);


### PR DESCRIPTION
## Summary

Automatische Datenbank-Initialisierung beim ersten Container-Start, wenn keine `products.db` existiert.

## Changes

- **`scripts/init-minimal-db.mjs`**: Erstellt Schema und importiert alle 3946 bekannten Ingredients
- **`scripts/docker-entrypoint.mjs`**: Node.js Entrypoint, der DB prüft und bei Bedarf initialisiert
- **`Dockerfile` & `Dockerfile.dev`**: Verwenden neuen Entrypoint
- **`docker-compose.yml`**: Explizites `image` und `container_name` für bessere Docker Desktop Kompatibilität

## Problem gelöst

Vorher: Bei frischem Start (leeres Volume) crasht die App mit "Database initialization failed"

Nachher: Container erstellt automatisch minimale DB mit Schema + Ingredients

## Test

```bash
# Dev
rm -rf data/products.db
docker compose up --build
# → [entrypoint] Creating minimal database...

# Prod
mkdir -p data-prod
docker build -t hashimoto-pcos:prod .
docker run -it --rm -v hashimoto-data:/app/data -p 3000:3000 hashimoto-pcos:prod
# → [entrypoint] Database initialized successfully
```

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)