### PR TITLE
feat(a11y): accessibility improvements for ScoreCard (#72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,24 @@ npm run test:e2e   # Playwright — all must pass
 - **Composite PK for repeated values:** use `(parent_id, position)` as PK, `(parent_id, foreign_id)` as UNIQUE.
 - **Whitelist hygiene:** no leading/trailing spaces, no empty strings, complete E-number ranges.
 
+## Accessibility (WCAG AA)
+
+All UI must meet **WCAG AA** contrast requirements (minimum **4.5:1** for normal text on white).
+
+**Score color values (WCAG AA compliant):**
+- `SCORE_CONFIG` in `src/components/ScoreCard.tsx` defines score label colors
+- NEUTRAL: `#a16207` (yellow-700, ~4.74:1 on white)
+- WENIGER GUT: `#c2410c` (orange-700, ~4.92:1 on white)
+- CSS custom properties synced in `src/app/globals.css`: `--color-score-neutral` and `--color-score-fair`
+- Always verify new score colors against white with a contrast ratio calculator before using
+
+**ARIA patterns:**
+- Emoji icons used as visual indicators need `role="img"` + `aria-label` describing the meaning, not the appearance (e.g., `aria-label="PCOS"` not `aria-label="Blaue-Kugel-Emoji"`)
+- Use a `CONDITION_LABEL` map (Record<Condition, string>) to pair with `CONDITION_ICON`
+- Tooltips use `role="tooltip"` and toggle buttons use `aria-expanded`
+
+**Missing data:** Never show bare "—" or empty values. Use "Nicht angegeben" with an info button + tooltip explaining the data is absent from the product database.
+
 ## What Does NOT Exist
 
 No ORM (raw `better-sqlite3`), no authentication, no Redux/Zustand, no i18n, no Prettier (ESLint only), no Service Worker, no analytics.

--- a/e2e/scorecard.spec.ts
+++ b/e2e/scorecard.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import { mockProductApi } from '../tests/helpers/mock-api';
 import vermeiden from '../tests/fixtures/products/vermeiden.json';
 import sehrGut from '../tests/fixtures/products/sehr-gut.json';
+import wenigerGut from '../tests/fixtures/products/weniger-gut.json';
 
 const SKIPPED_KEY = 'hashimoto-pcos-onboarding-skipped';
 
@@ -35,5 +36,22 @@ test.describe('ScoreCard Component', () => {
     await mockProductApi(page, sehrGut.barcode, sehrGut);
     await page.goto(`/result/${sehrGut.barcode}`);
     await expect(page.getByText(/sehr gut/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('condition_icon_has_accessible_aria_label', async ({ page }) => {
+    // Schafsalami (weniger-gut.json) has no fiber field which triggers
+    // PCOS-specific protein bonus in breakdown — condition icon appears.
+    // Set PCOS profile so the condition icon shows.
+    await mockProductApi(page, wenigerGut.barcode, wenigerGut);
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'hashimoto-pcos-user-profile',
+        JSON.stringify({ condition: 'pcos', glutenSensitive: false, lactoseIntolerant: false })
+      );
+    });
+    await page.goto(`/result/${wenigerGut.barcode}`);
+    await expect(
+      page.locator('[role="img"][aria-label="PCOS"]')
+    ).toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/scorecard.spec.ts
+++ b/e2e/scorecard.spec.ts
@@ -54,4 +54,21 @@ test.describe('ScoreCard Component', () => {
       page.locator('[role="img"][aria-label="PCOS"]')
     ).toBeVisible({ timeout: 5000 });
   });
+
+  test('missing_nutriment_shows_nicht_angegeben', async ({ page }) => {
+    // weniger-gut.json (Schafsalami) has no "fiber" field →
+    // "Ballaststoffe" NutrientRow value is undefined
+    await mockProductApi(page, wenigerGut.barcode, wenigerGut);
+    await page.goto(`/result/${wenigerGut.barcode}`);
+    await expect(page.getByText('Nicht angegeben').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('missing_nutriment_tooltip_opens_on_click', async ({ page }) => {
+    await mockProductApi(page, wenigerGut.barcode, wenigerGut);
+    await page.goto(`/result/${wenigerGut.barcode}`);
+    await page.getByRole('button', { name: /warum fehlt dieser wert/i }).first().click();
+    await expect(
+      page.getByRole('tooltip', { name: /diese angabe fehlt in der produktdatenbank/i })
+    ).toBeVisible({ timeout: 5000 });
+  });
 });

--- a/e2e/scorecard.spec.ts
+++ b/e2e/scorecard.spec.ts
@@ -3,6 +3,8 @@ import { mockProductApi } from '../tests/helpers/mock-api';
 import vermeiden from '../tests/fixtures/products/vermeiden.json';
 import sehrGut from '../tests/fixtures/products/sehr-gut.json';
 import wenigerGut from '../tests/fixtures/products/weniger-gut.json';
+import brokkoliSalat from '../tests/fixtures/products/brokkoli-salat.json';
+import honig from '../tests/fixtures/products/honig.json';
 
 const SKIPPED_KEY = 'hashimoto-pcos-onboarding-skipped';
 
@@ -52,6 +54,38 @@ test.describe('ScoreCard Component', () => {
     await page.goto(`/result/${wenigerGut.barcode}`);
     await expect(
       page.locator('[role="img"][aria-label="PCOS"]')
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('condition_icon_hashimoto_has_aria_label', async ({ page }) => {
+    // brokkoli-salat contains Brokkoli (raw Brassica = goitrogen) → Hashimoto icon
+    await mockProductApi(page, brokkoliSalat.barcode, brokkoliSalat);
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'hashimoto-pcos-user-profile',
+        JSON.stringify({ condition: 'hashimoto', glutenSensitive: false, lactoseIntolerant: false })
+      );
+    });
+    await page.goto(`/result/${brokkoliSalat.barcode}`);
+    await expect(
+      page.locator('[role="img"][aria-label="Hashimoto-Thyreoiditis"]')
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test('condition_icon_both_profile_shows_both_aria_label', async ({ page }) => {
+    // honig: 80g sugar (>20g) → sugar malus with condition="both"
+    // For "both" profile, sugar > 20g triggers a breakdown item with condition="both"
+    await mockProductApi(page, honig.barcode, honig);
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'hashimoto-pcos-user-profile',
+        JSON.stringify({ condition: 'both', glutenSensitive: false, lactoseIntolerant: false })
+      );
+    });
+    await page.goto(`/result/${honig.barcode}`);
+    // Sugar > 20g with "both" profile creates item with aria-label "Hashimoto-Thyreoiditis und PCOS"
+    await expect(
+      page.locator('[role="img"][aria-label="Hashimoto-Thyreoiditis und PCOS"]')
     ).toBeVisible({ timeout: 5000 });
   });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,8 +132,8 @@
   /* Score colors — English, kebab-case */
   --color-score-very-good: #22c55e;
   --color-score-good: #84cc16;
-  --color-score-neutral: #eab308;
-  --color-score-fair: #f97316;
+  --color-score-neutral: #a16207;
+  --color-score-fair: #c2410c;
   --color-score-avoid: #ef4444;
 
   /* Touch-friendly spacing (44px minimum tap targets) */

--- a/src/components/ScoreCard.color-contrast.test.ts
+++ b/src/components/ScoreCard.color-contrast.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { SCORE_CONFIG } from "./ScoreCard";
+
+function linearize(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const l1 = luminance(fg);
+  const l2 = luminance(bg);
+  const [light, dark] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (light + 0.05) / (dark + 0.05);
+}
+
+const WHITE = "#ffffff";
+const WCAG_AA_NORMAL = 4.5;
+
+describe("SCORE_CONFIG color contrast (WCAG AA)", () => {
+  it("NEUTRAL color meets 4.5:1 against white", () => {
+    const ratio = contrastRatio(SCORE_CONFIG.NEUTRAL.color, WHITE);
+    expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_NORMAL);
+  });
+
+  it("WENIGER GUT color meets 4.5:1 against white", () => {
+    const ratio = contrastRatio(SCORE_CONFIG["WENIGER GUT"].color, WHITE);
+    expect(ratio).toBeGreaterThanOrEqual(WCAG_AA_NORMAL);
+  });
+});

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Star, RotateCcw, Save, Check, AlertTriangle, Info } from "lucide-react";
 import type { Product } from "@/core/domain/product";
 import type { ScoreResult, ScoreBreakdownItem } from "@/core/domain/score";
@@ -292,6 +292,29 @@ function NutrientRow({
   unit: string;
 }) {
   const [showTooltip, setShowTooltip] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!showTooltip) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
+        setShowTooltip(false);
+      }
+    };
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowTooltip(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [showTooltip]);
 
   if (value === undefined || value === null) {
     return (
@@ -300,11 +323,11 @@ function NutrientRow({
         <span className="relative flex items-center gap-1">
           <span>Nicht angegeben</span>
           <button
+            ref={buttonRef}
             type="button"
             aria-label="Warum fehlt dieser Wert?"
             aria-expanded={showTooltip}
             onClick={() => setShowTooltip((v) => !v)}
-            onBlur={() => setShowTooltip(false)}
             className="rounded-full p-0.5 hover:bg-muted transition-colors"
           >
             <Info className="h-3.5 w-3.5" />

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -23,6 +23,12 @@ const CONDITION_ICON: Record<Condition, string> = {
   both: "🦋🔵",
 };
 
+const CONDITION_LABEL: Record<Condition, string> = {
+  hashimoto: "Hashimoto-Thyreoiditis",
+  pcos: "PCOS",
+  both: "Hashimoto-Thyreoiditis und PCOS",
+};
+
 export const SCORE_CONFIG = {
   "SEHR GUT": {
     color: "#22c55e",
@@ -159,7 +165,15 @@ export function ScoreCard({
                     )}
                   </span>
                   <span className="flex-1 text-foreground">
-                    {item.condition && <span className="mr-1">{CONDITION_ICON[item.condition]}</span>}
+                    {item.condition && (
+                      <span
+                        className="mr-1"
+                        role="img"
+                        aria-label={CONDITION_LABEL[item.condition]}
+                      >
+                        {CONDITION_ICON[item.condition]}
+                      </span>
+                    )}
                     {item.reason}
                   </span>
                   <span

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -23,7 +23,7 @@ const CONDITION_ICON: Record<Condition, string> = {
   both: "🦋🔵",
 };
 
-const SCORE_CONFIG = {
+export const SCORE_CONFIG = {
   "SEHR GUT": {
     color: "#22c55e",
     bgColor: "bg-green-50",
@@ -39,14 +39,14 @@ const SCORE_CONFIG = {
     borderColor: "border-lime-200",
   },
   NEUTRAL: {
-    color: "#eab308",
+    color: "#a16207",
     bgColor: "bg-yellow-50",
     textColor: "text-yellow-700",
     stars: 3,
     borderColor: "border-yellow-200",
   },
   "WENIGER GUT": {
-    color: "#f97316",
+    color: "#c2410c",
     bgColor: "bg-orange-50",
     textColor: "text-orange-700",
     stars: 2,

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -291,14 +291,37 @@ function NutrientRow({
   value?: number;
   unit: string;
 }) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
   if (value === undefined || value === null) {
     return (
       <div className="flex justify-between text-muted-foreground">
         <span>{label}</span>
-        <span>—</span>
+        <span className="relative flex items-center gap-1">
+          <span>Nicht angegeben</span>
+          <button
+            type="button"
+            aria-label="Warum fehlt dieser Wert?"
+            aria-expanded={showTooltip}
+            onClick={() => setShowTooltip((v) => !v)}
+            onBlur={() => setShowTooltip(false)}
+            className="rounded-full p-0.5 hover:bg-muted transition-colors"
+          >
+            <Info className="h-3.5 w-3.5" />
+          </button>
+          {showTooltip && (
+            <span
+              role="tooltip"
+              className="pointer-events-none absolute right-0 bottom-full mb-1 z-10 w-52 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-card"
+            >
+              Diese Angabe fehlt in der Produktdatenbank
+            </span>
+          )}
+        </span>
       </div>
     );
   }
+
   return (
     <div className="flex justify-between">
       <span className="text-foreground">{label}</span>

--- a/tests/fixtures/products/honig.json
+++ b/tests/fixtures/products/honig.json
@@ -1,0 +1,19 @@
+{
+  "barcode": "9999000099999",
+  "name": "Blütenhonig",
+  "brand": "Test",
+  "imageUrl": "",
+  "labels": [],
+  "ingredients": "Honig",
+  "categories": [],
+  "additives": [],
+  "nutriments": {
+    "energyKcal": 320,
+    "sugars": 80,
+    "fat": 0,
+    "saturatedFat": 0,
+    "fiber": 0,
+    "protein": 0.3,
+    "salt": 0
+  }
+}


### PR DESCRIPTION
## Summary
Three accessibility improvements to `ScoreCard.tsx` addressing issue #72:

- **WCAG AA color contrast**: NEUTRAL (`#eab308` → `#a16207`, ~1.86:1 → ~4.74:1) and WENIGER GUT (`#f97316` → `#c2410c`, ~2.67:1 → ~4.92:1) now exceed the 4.5:1 minimum contrast ratio
- **ARIA labels on condition icons**: Screen readers now announce "Hashimoto-Thyreoiditis", "PCOS", or "Hashimoto-Thyreoiditis und PCOS" instead of raw emoji descriptions
- **Informative missing value text**: "Nicht angegeben" replaces em-dash with a toggleable tooltip (click-outside + Escape to close) explaining the value is absent from the product database

## PR #96 Review Fixes Applied
1. **Tooltip UX**: Added `useRef` + `useEffect` for click-outside detection and Escape key handling. Removed redundant `onBlur`.
2. **Test coverage**: Added E2E tests for `hashimoto` and `both` condition aria-labels.
3. **Tooltip aria**: Added `aria-expanded` to the info toggle button.

## Test plan
- [x] `npm run test:run` — 267/267 Vitest tests pass
- [x] `npm run lint` — 0 errors, 8 pre-existing warnings
- [x] `npm run build` — production build succeeds
- [x] `npm run test:e2e` — 100/101 E2E tests pass (1 pre-existing flaky test unrelated to this change)
- [x] New Vitest test (`ScoreCard.color-contrast.test.ts`) verifies WCAG AA contrast ratios
- [x] New E2E tests verify aria-label on condition icons (PCOS, hashimoto, both) and missing nutriments tooltip

Closes #72