### PR TITLE
feat(nav): Navigation & Information Architecture improvements (#74)

### DIFF
--- a/e2e/bottom-nav.spec.ts
+++ b/e2e/bottom-nav.spec.ts
@@ -11,7 +11,7 @@ test.describe('BottomNav Component', () => {
     await page.goto('/');
     await expect(page.getByRole('link', { name: /home/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /scanner/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /liste/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /suche/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /profil/i })).toBeVisible();
   });
 
@@ -44,7 +44,7 @@ test.describe('BottomNav Component', () => {
     await expect(page).toHaveURL('/scanner');
 
     await page.goto('/');
-    await page.getByRole('link', { name: /liste/i }).click();
+    await page.getByRole('link', { name: /suche/i }).click();
     await expect(page).toHaveURL('/products');
 
     await page.goto('/');

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -26,6 +26,6 @@ test.describe('Startseite (/)', () => {
   test('bottom_nav_present', async ({ page }) => {
     await expect(page.getByRole('link', { name: /home/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /scanner/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /liste/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /suche/i })).toBeVisible();
   });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -17,7 +17,7 @@ test.describe('Navigation & Routing', () => {
 
   test('homepage_navigates_to_products', async ({ page }) => {
     await page.goto('/');
-    await page.getByRole('link', { name: /liste/i }).click();
+    await page.getByRole('link', { name: /suche/i }).click();
     await expect(page).toHaveURL('/products');
   });
 
@@ -30,7 +30,7 @@ test.describe('Navigation & Routing', () => {
     await expect(page.getByRole('link', { name: /scanner/i })).toHaveAttribute('aria-current', 'page');
 
     await page.goto('/products');
-    await expect(page.getByRole('link', { name: /liste/i })).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByRole('link', { name: /suche/i })).toHaveAttribute('aria-current', 'page');
   });
 
   test('all_routes_return_200', async ({ page }) => {

--- a/e2e/scanner.spec.ts
+++ b/e2e/scanner.spec.ts
@@ -88,6 +88,11 @@ test.describe('Scanner page (/scanner)', () => {
     await expect(page.locator('input[placeholder*="Barcode"]').first()).toBeVisible();
   });
 
+  test('camera_mode_manual_input_has_card_heading', async ({ page }) => {
+    await page.getByRole('button', { name: /kamera/i }).click();
+    await expect(page.getByText('Barcode manuell eingeben')).toBeVisible();
+  });
+
   test('reset_clears_error', async ({ page }) => {
     await page.getByRole('button', { name: /manuell/i }).click();
     const input = page.getByRole('textbox');

--- a/e2e/scorecard.spec.ts
+++ b/e2e/scorecard.spec.ts
@@ -105,4 +105,12 @@ test.describe('ScoreCard Component', () => {
       page.getByRole('tooltip', { name: /diese angabe fehlt in der produktdatenbank/i })
     ).toBeVisible({ timeout: 5000 });
   });
+
+  test('education_link_visible_in_score_badge', async ({ page }) => {
+    await mockProductApi(page, vermeiden.barcode, vermeiden);
+    await page.goto(`/result/${vermeiden.barcode}`);
+    const educationLink = page.getByRole('link', { name: /warum diese bewertung/i });
+    await expect(educationLink).toBeVisible({ timeout: 5000 });
+    await expect(educationLink).toHaveAttribute('href', '/education');
+  });
 });

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -69,6 +69,15 @@ test.describe('Search page (/products)', () => {
     await expect(page.getByText('Keine Ergebnisse gefunden')).toBeVisible({ timeout: 5000 });
   });
 
+  test('no_results_shows_scanner_cta', async ({ page }) => {
+    await mockSearchApi(page, []);
+    await page.getByRole('textbox', { name: /suchen/i }).fill('xyzabc123nonexistentproduct');
+    await page.getByRole('button', { name: /suchen/i }).click();
+    const ctaLink = page.getByRole('link', { name: /stattdessen scannen/i });
+    await expect(ctaLink).toBeVisible({ timeout: 5000 });
+    await expect(ctaLink).toHaveAttribute('href', '/scanner');
+  });
+
   test('reset_button_clears_search', async ({ page }) => {
     await mockSearchApi(page, MOCK_PRODUCTS);
     await page.getByRole('textbox', { name: /suchen/i }).fill('Milch');

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect, Suspense } from "react";
 import { useRouter } from "next/navigation";
-import { Search, Loader2, PackageX, ServerCrash } from "lucide-react";
+import { Search, Loader2, PackageX, ServerCrash, ScanBarcode } from "lucide-react";
 import { calculateScore } from "@/core/services/scoring-service";
 import type { Product } from "@/core/domain/product";
 import type { ScoreResult } from "@/core/domain/score";
@@ -474,6 +474,13 @@ function ProductsPageContent() {
           <p className="text-base text-muted-foreground max-w-xs leading-relaxed">
             Versuche einen anderen Suchbegriff oder eine andere Kategorie.
           </p>
+          <Link
+            href="/scanner"
+            className="mt-6 flex items-center gap-2.5 rounded-xl bg-primary px-6 py-3.5 text-base font-semibold text-primary-foreground hover:bg-primary-600 active:scale-[0.98] transition-all shadow-soft touch-target"
+          >
+            <ScanBarcode className="h-5 w-5" />
+            Stattdessen scannen
+          </Link>
         </div>
       )}
     </div>

--- a/src/app/scanner/page.tsx
+++ b/src/app/scanner/page.tsx
@@ -114,23 +114,21 @@ export default function ScannerPage() {
           )}
 
           {/* Manual fallback in camera mode */}
-          <div className="relative py-3">
-            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-              <span className="text-sm text-muted-foreground bg-background/80 px-3 py-1.5 rounded-full">
-                Oder Barcode manuell eingeben:
-              </span>
-            </div>
+          <div className="card-warm p-6">
+            <h3 className="mb-4 text-base font-semibold text-foreground">
+              Barcode manuell eingeben
+            </h3>
+            <form onSubmit={handleManualSubmit}>
+              <input
+                type="text"
+                value={barcode}
+                onChange={(e) => setBarcode(e.target.value.replace(/\D/g, ""))}
+                placeholder="Barcode hier eingeben..."
+                className="w-full rounded-xl border border-border bg-background px-5 py-4 text-lg tracking-wider text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-all"
+                maxLength={13}
+              />
+            </form>
           </div>
-          <form onSubmit={handleManualSubmit}>
-            <input
-              type="text"
-              value={barcode}
-              onChange={(e) => setBarcode(e.target.value.replace(/\D/g, ""))}
-              placeholder="Barcode hier eingeben..."
-              className="w-full rounded-xl border border-border bg-background px-5 py-4 text-lg tracking-wider text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-all"
-              maxLength={13}
-            />
-          </form>
         </div>
       )}
 

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
 import { Star, RotateCcw, Save, Check, AlertTriangle, Info } from "lucide-react";
 import type { Product } from "@/core/domain/product";
 import type { ScoreResult, ScoreBreakdownItem } from "@/core/domain/score";
@@ -137,6 +138,13 @@ export function ScoreCard({
             {scoreResult.label}
           </span>
         </div>
+        <Link
+          href="/education"
+          className="mt-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
+        >
+          <Info className="h-4 w-4" />
+          Warum diese Bewertung?
+        </Link>
       </div>
 
       {/* Bonus/Malus Breakdown */}

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { Home, ScanBarcode, List, Settings } from "lucide-react";
+import { Home, ScanBarcode, Search, Settings } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 const navItems = [
   { href: "/", icon: Home, label: "Home" },
   { href: "/scanner", icon: ScanBarcode, label: "Scanner" },
-  { href: "/products", icon: List, label: "Liste" },
+  { href: "/products", icon: Search, label: "Suche" },
   { href: "/settings", icon: Settings, label: "Profil" },
 ];
 


### PR DESCRIPTION
## Summary
- **Nav:** Rename "Liste" → "Suche" with Search icon in bottom navigation (Issue #74 Sub-Issue 1)
- **Search:** Add "Stattdessen scannen" CTA button to empty search results (Issue #74 Sub-Issue 2)
- **ScoreCard:** Add "Warum diese Bewertung?" link to `/education` page in score badge (Issue #74 Sub-Issue 3)
- **Scanner:** Wrap camera-mode manual input in card with visible heading "Barcode manuell eingeben" (Issue #74 Sub-Issue 4)

## Test Plan
- [ ] `npm run test:run` — 267 Vitest tests pass
- [ ] `npm run test:e2e` — 104 E2E tests pass
- [ ] `npm run build` — Exit 0
- [ ] Bottom nav shows "Suche" with Search icon
- [ ] Empty search results show scanner CTA button
- [ ] ScoreCard shows education link under score badge
- [ ] Scanner camera mode shows manual input in card container

Closes shaunclaw07/hashimoto-pcos#74

🤖 Generated with [Claude Code](https://claude.com/claude-code)