### PR TITLE
feat(ui): improve nutrition grid layout for 375px mobile (#102)

### DIFF
--- a/e2e/scorecard.spec.ts
+++ b/e2e/scorecard.spec.ts
@@ -37,7 +37,7 @@ test.describe('ScoreCard Component', () => {
   test('sehr_gut_label_shown_for_high_score_product', async ({ page }) => {
     await mockProductApi(page, sehrGut.barcode, sehrGut);
     await page.goto(`/result/${sehrGut.barcode}`);
-    await expect(page.getByText(/sehr gut/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('SEHR GUT', { exact: true })).toBeVisible({ timeout: 5000 });
   });
 
   test('condition_icon_has_accessible_aria_label', async ({ page }) => {
@@ -112,5 +112,51 @@ test.describe('ScoreCard Component', () => {
     const educationLink = page.getByRole('link', { name: /warum diese bewertung/i });
     await expect(educationLink).toBeVisible({ timeout: 5000 });
     await expect(educationLink).toHaveAttribute('href', '/education');
+  });
+
+  test('nutrient_row_uses_vertical_card_layout', async ({ page }) => {
+    // Energie row should have label on top, value below in card tile style
+    await mockProductApi(page, sehrGut.barcode, sehrGut);
+    await page.goto(`/result/${sehrGut.barcode}`);
+    const energieRow = page.locator('.grid.grid-cols-2 > div').filter({ hasText: 'Energie' }).first();
+    // Label should be small/muted and appear above the bold value
+    await expect(energieRow.locator('span').first()).toContainText('Energie');
+    await expect(energieRow.locator('span').last()).toContainText('kcal');
+    // Card tile should have background
+    await expect(energieRow).toHaveClass(/rounded-xl/);
+  });
+
+  test('saturated_fat_label_shortened_to_ges_fettsaeuren', async ({ page }) => {
+    await mockProductApi(page, sehrGut.barcode, sehrGut);
+    await page.goto(`/result/${sehrGut.barcode}`);
+    // Should find "Ges. Fettsäuren" not "davon gesättigt"
+    await expect(page.getByText('Ges. Fettsäuren')).toBeVisible();
+    await expect(page.getByText('davon gesättigt')).not.toBeVisible();
+  });
+
+  test('product_name_allows_wrapping_up_to_two_lines', async ({ page }) => {
+    // Very long product name should wrap and truncate at 2 lines max
+    await mockProductApi(page, sehrGut.barcode, sehrGut);
+    await page.goto(`/result/${sehrGut.barcode}`);
+    const nameEl = page.locator('h2').filter({ hasText: /./ }).first();
+    await expect(nameEl).toHaveClass(/line-clamp-2/);
+  });
+
+  test('score_badge_shows_plain_language_description', async ({ page }) => {
+    await mockProductApi(page, sehrGut.barcode, sehrGut);
+    await page.goto(`/result/${sehrGut.barcode}`);
+    // "Sehr gut" should have description "Sehr gut für Ihren Ernährungsplan"
+    await expect(page.getByText('Sehr gut für Ihren Ernährungsplan')).toBeVisible();
+  });
+
+  test('score_legend_circles_fit_on_375px_viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    // Legend section should not overflow horizontally
+    const legend = page.locator('section').filter({ hasText: 'So funktioniert die Bewertung' });
+    const legendBox = await legend.boundingBox();
+    expect(legendBox?.width).toBeLessThanOrEqual(375);
+    // All 5 labels should be visible without horizontal scroll
+    await expect(page.getByText('Vermeiden')).toBeVisible();
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,33 +66,33 @@ export default function HomePage() {
       {/* Score Legend */}
       <section className="px-6 py-8">
         <h2 className="mb-5 text-xl font-semibold">So funktioniert die Bewertung</h2>
-        <div className="grid grid-cols-5 gap-3 text-center">
+        <div className="grid grid-cols-5 gap-2 text-center">
           <div className="flex flex-col items-center gap-2">
-            <div className="h-12 w-12 rounded-full bg-score-very-good shadow-soft flex items-center justify-center">
+            <div className="h-10 w-10 rounded-full bg-score-very-good shadow-soft flex items-center justify-center">
               <span className="text-white text-lg">✓</span>
             </div>
             <span className="text-sm font-medium text-score-very-good">Sehr gut</span>
           </div>
           <div className="flex flex-col items-center gap-2">
-            <div className="h-12 w-12 rounded-full bg-score-good shadow-soft flex items-center justify-center">
+            <div className="h-10 w-10 rounded-full bg-score-good shadow-soft flex items-center justify-center">
               <span className="text-white text-lg">✓</span>
             </div>
             <span className="text-sm font-medium text-score-good">Gut</span>
           </div>
           <div className="flex flex-col items-center gap-2">
-            <div className="h-12 w-12 rounded-full bg-score-neutral shadow-soft flex items-center justify-center">
+            <div className="h-10 w-10 rounded-full bg-score-neutral shadow-soft flex items-center justify-center">
               <span className="text-white text-lg">~</span>
             </div>
             <span className="text-sm font-medium text-score-neutral">Neutral</span>
           </div>
           <div className="flex flex-col items-center gap-2">
-            <div className="h-12 w-12 rounded-full bg-score-fair shadow-soft flex items-center justify-center">
+            <div className="h-10 w-10 rounded-full bg-score-fair shadow-soft flex items-center justify-center">
               <span className="text-white text-lg">!</span>
             </div>
             <span className="text-sm font-medium text-score-fair">Weniger gut</span>
           </div>
           <div className="flex flex-col items-center gap-2">
-            <div className="h-12 w-12 rounded-full bg-score-avoid shadow-soft flex items-center justify-center">
+            <div className="h-10 w-10 rounded-full bg-score-avoid shadow-soft flex items-center justify-center">
               <span className="text-white text-lg">✗</span>
             </div>
             <span className="text-sm font-medium text-score-avoid">Vermeiden</span>

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -37,6 +37,7 @@ export const SCORE_CONFIG = {
     textColor: "text-[var(--color-score-very-good-text)]",
     stars: 5,
     borderColor: "border-[var(--color-score-very-good)]/20",
+    description: "Sehr gut für Ihren Ernährungsplan",
   },
   GUT: {
     color: "var(--color-score-good)",
@@ -44,6 +45,7 @@ export const SCORE_CONFIG = {
     textColor: "text-[var(--color-score-good-text)]",
     stars: 4,
     borderColor: "border-[var(--color-score-good)]/20",
+    description: "Gut geeignet für Sie",
   },
   NEUTRAL: {
     color: "var(--color-score-neutral)",
@@ -51,6 +53,7 @@ export const SCORE_CONFIG = {
     textColor: "text-[var(--color-score-neutral-text)]",
     stars: 3,
     borderColor: "border-[var(--color-score-neutral)]/20",
+    description: "In Maßen geeignet",
   },
   "WENIGER GUT": {
     color: "var(--color-score-fair)",
@@ -58,6 +61,7 @@ export const SCORE_CONFIG = {
     textColor: "text-[var(--color-score-fair-text)]",
     stars: 2,
     borderColor: "border-[var(--color-score-fair)]/20",
+    description: "Nur selten empfohlen",
   },
   VERMEIDEN: {
     color: "var(--color-score-avoid)",
@@ -65,6 +69,7 @@ export const SCORE_CONFIG = {
     textColor: "text-[var(--color-score-avoid-text)]",
     stars: 1,
     borderColor: "border-[var(--color-score-avoid)]/20",
+    description: "Bitte meiden",
   },
 } as const;
 
@@ -111,7 +116,7 @@ export function ScoreCard({
           </div>
         )}
         <div className="flex flex-col justify-center min-w-0 flex-1">
-          <h2 className="font-bold text-xl leading-tight truncate text-foreground">
+          <h2 className="font-bold text-xl leading-tight line-clamp-2 text-foreground">
             {product.name || "Unbekanntes Produkt"}
           </h2>
           {product.brand && (
@@ -138,6 +143,11 @@ export function ScoreCard({
             {scoreResult.label}
           </span>
         </div>
+        {config.description && (
+          <p className={`mt-1 text-sm opacity-80 ${config.textColor}`}>
+            {config.description}
+          </p>
+        )}
         <Link
           href="/education"
           className="mt-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
@@ -213,10 +223,10 @@ export function ScoreCard({
         <h3 className="mb-4 text-base font-semibold text-foreground">
           Nährwerte (pro 100g)
         </h3>
-        <div className="grid grid-cols-2 gap-3 text-base">
+        <div className="grid grid-cols-2 gap-2.5">
           <NutrientRow label="Energie" value={n.energyKcal} unit="kcal" />
           <NutrientRow label="Fett" value={n.fat} unit="g" />
-          <NutrientRow label="davon gesättigt" value={n.saturatedFat} unit="g" />
+          <NutrientRow label="Ges. Fettsäuren" value={n.saturatedFat} unit="g" />
           <NutrientRow label="Zucker" value={n.sugars} unit="g" />
           <NutrientRow label="Ballaststoffe" value={n.fiber} unit="g" />
           <NutrientRow label="Protein" value={n.protein} unit="g" />
@@ -326,10 +336,9 @@ function NutrientRow({
 
   if (value === undefined || value === null) {
     return (
-      <div className="flex justify-between text-muted-foreground">
-        <span>{label}</span>
-        <span className="relative flex items-center gap-1">
-          <span>Nicht angegeben</span>
+      <div className="relative flex flex-col gap-1 rounded-xl bg-muted/40 px-3 py-3">
+        <span className="flex items-center gap-1 text-xs text-muted-foreground leading-tight">
+          {label}
           <button
             ref={buttonRef}
             type="button"
@@ -340,23 +349,24 @@ function NutrientRow({
           >
             <Info className="h-3.5 w-3.5" />
           </button>
-          {showTooltip && (
-            <span
-              role="tooltip"
-              className="pointer-events-none absolute right-0 bottom-full mb-1 z-10 w-52 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-card"
-            >
-              Diese Angabe fehlt in der Produktdatenbank
-            </span>
-          )}
         </span>
+        <span className="text-sm font-semibold text-foreground">Nicht angegeben</span>
+        {showTooltip && (
+          <span
+            role="tooltip"
+            className="pointer-events-none absolute left-1/2 top-full -translate-x-1/2 z-10 mt-1 w-52 rounded-lg border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-card"
+          >
+            Diese Angabe fehlt in der Produktdatenbank
+          </span>
+        )}
       </div>
     );
   }
 
   return (
-    <div className="flex justify-between">
-      <span className="text-foreground">{label}</span>
-      <span className="font-semibold text-foreground">
+    <div className="flex flex-col gap-1 rounded-xl bg-muted/40 px-3 py-3">
+      <span className="text-xs text-muted-foreground leading-tight">{label}</span>
+      <span className="text-base font-semibold text-foreground">
         {value.toFixed(1)} {unit}
       </span>
     </div>


### PR DESCRIPTION
## Summary

- Transform nutrition grid cells into vertical card tiles (label on top, bold value below) with `bg-muted/40` background
- Shorten saturated fat label `"davon gesättigt"` → `"Ges. Fettsäuren"`
- Product name: `truncate` → `line-clamp-2` to allow wrapping up to 2 lines
- Add plain-language descriptions to all 5 `SCORE_CONFIG` levels (e.g., `"Sehr gut für Ihren Ernährungsplan"`)
- Reduce score legend circles from `h-12 w-12` → `h-10 w-10` and gap `3` → `2` so all 5 fit on 375px viewport
- Info button for missing nutriment values now appears inline with the label row

## Test plan

- [ ] `npm run test:run` — 269 vitest tests pass
- [ ] `npm run test:e2e` — 109 Playwright tests pass
- [ ] `npm run lint` — no errors
- [ ] `npm run build` — succeeds
- [ ] Manual: 375px viewport — nutrition tiles show label above value, all 5 legend circles fit without horizontal scroll

Closes #102