### PR TITLE
ci(docker): add workflow to publish images to GHCR on release tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         id: push

--- a/README.md
+++ b/README.md
@@ -246,6 +246,37 @@ docker compose logs -f
 
 **Hinweis:** Die lokale Datenbank ist optional. Die App funktioniert auch ohne `products.db` — in diesem Fall fallen alle Suchanfragen auf die OpenFoodFacts-API zurück (keine lokalen DACH-Produkte, keine Zero-Rating-Logik). Für zuverlässige Performance und Zero-Rating wird eine lokale DB empfohlen.
 
+### GitHub Container Registry (Release)
+
+Docker-Images werden automatisch nach GitHub Container Registry (GHCR) veröffentlicht, wenn ein SemVer-Tag gepusht wird:
+
+```bash
+# Einen neuen Release taggen
+git tag v1.0.0
+git push origin v1.0.0
+
+# Oder mit einem Prefix für Vorab-Releases
+git tag v0.1.0-beta.1
+git push origin v0.1.0-beta.1
+```
+
+**Was passiert:**
+- Workflow triggert auf Tag-Push (`v*.*.*` Pattern)
+- Image wird gebaut und nach `ghcr.io/shaunclaw07/hashimoto-pcos` gepusht
+- Folgende Tags werden erstellt: `v1.0.0`, `1.0`, `1`, `latest`
+
+**Image verwenden:**
+```bash
+# Latest Version pullen
+docker pull ghcr.io/shaunclaw07/hashimoto-pcos:latest
+
+# Spezifische Version pullen
+docker pull ghcr.io/shaunclaw07/hashimoto-pcos:v1.0.0
+
+# Container starten
+docker run -p 3000:3000 ghcr.io/shaunclaw07/hashimoto-pcos:latest
+```
+
 ### Kubernetes
 
 Die Kubernetes-Manifests liegen unter `k8s/` und werden mit `kubectl apply -k k8s/` angewendet:


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and push Docker images to GHCR on semver tag pushes
- Trigger on tags matching `v*.*.*` pattern
- Tag images with version, major.minor, major, and latest
- Enable GitHub Actions cache for faster builds
- Generate artifact attestation for supply chain security

## Test Plan
- [ ] Verify workflow triggers on tag push
- [ ] Confirm image appears in GitHub Container Registry
- [ ] Test pulling and running the image locally

Closes #106