### PR TITLE
fix(core): move clamp into core-safe utility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ export default [
     },
   },
   {
-    // Erzwingt: src/core/ darf NICHT aus infrastructure/ oder app/ importieren
+    // Enforce: src/core/ must NOT import from infrastructure/, app/, or lib/
     files: ["src/core/**/*.ts"],
     rules: {
       "no-restricted-imports": [
@@ -19,9 +19,9 @@ export default [
         {
           patterns: [
             {
-              group: ["**/infrastructure/**", "**/app/**", "better-sqlite3", "next/*"],
+              group: ["**/infrastructure/**", "**/app/**", "**/lib/**", "better-sqlite3", "next/*"],
               message:
-                "core/ darf keine Abhängigkeiten zu infrastructure/, app/ oder Framework-Packages haben.",
+                "core/ must not depend on infrastructure/, app/, lib/, or framework packages.",
             },
           ],
         },

--- a/src/core/services/scoring-service.ts
+++ b/src/core/services/scoring-service.ts
@@ -2,7 +2,7 @@
 import type { Product } from "../domain/product";
 import type { ScoreResult, ScoreBreakdownItem } from "../domain/score";
 import type { UserProfile, Condition } from "../domain/user-profile";
-import { clamp } from "../../lib/utils";
+import { clamp } from "../shared/math";
 
 /**
  * Validates nutriments and clamps them to physiologically realistic ranges.

--- a/src/core/shared/math.test.ts
+++ b/src/core/shared/math.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { clamp } from "./math";
+
+describe("clamp", () => {
+  it("returns min when value is below min", () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+  });
+
+  it("returns max when value is above max", () => {
+    expect(clamp(15, 0, 10)).toBe(10);
+  });
+
+  it("returns value when inside range", () => {
+    expect(clamp(7, 0, 10)).toBe(7);
+  });
+});

--- a/src/core/shared/math.test.ts
+++ b/src/core/shared/math.test.ts
@@ -7,11 +7,23 @@ describe("clamp", () => {
     expect(clamp(-5, 0, 10)).toBe(0);
   });
 
+  it("returns min when value equals min", () => {
+    expect(clamp(0, 0, 10)).toBe(0);
+  });
+
   it("returns max when value is above max", () => {
     expect(clamp(15, 0, 10)).toBe(10);
   });
 
+  it("returns max when value equals max", () => {
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+
   it("returns value when inside range", () => {
     expect(clamp(7, 0, 10)).toBe(7);
+  });
+
+  it("throws when min is greater than max", () => {
+    expect(() => clamp(5, 10, 0)).toThrowError("clamp requires min <= max");
   });
 });

--- a/src/core/shared/math.ts
+++ b/src/core/shared/math.ts
@@ -1,0 +1,3 @@
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/core/shared/math.ts
+++ b/src/core/shared/math.ts
@@ -1,3 +1,7 @@
 export function clamp(value: number, min: number, max: number): number {
+  if (min > max) {
+    throw new RangeError("clamp requires min <= max");
+  }
+
   return Math.min(Math.max(value, min), max);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,14 +4,3 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-/**
- * Clamps a value between min and max.
- * @param value The value to clamp
- * @param min Minimum value
- * @param max Maximum value
- */
-export function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
-


### PR DESCRIPTION
## Summary
- move clamp from src/lib/utils.ts to core-safe src/core/shared/math.ts
- switch scoring-service to import from core shared utility
- remove clamp from UI utilities (src/lib/utils.ts)
- add lint boundary so src/core/** cannot import from src/lib/**
- add unit tests for the new clamp utility

## Verification
- npm run lint
- npm run test:run
- npm run test:e2e
- npm run build

Closes #114