### PR TITLE
fix(result): replace hard navigation with router.push in handleRescan

### DIFF
--- a/src/app/result/[barcode]/page.tsx
+++ b/src/app/result/[barcode]/page.tsx
@@ -63,7 +63,7 @@ export default function ResultPage() {
   }, [barcode]);
 
   function handleRescan() {
-    window.location.href = "/scanner";
+    router.push("/scanner");
   }
 
   function handleSave() {

--- a/src/app/result/[barcode]/page.tsx
+++ b/src/app/result/[barcode]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useParams } from "next/navigation";
 import { ScoreCard } from "@/components/ScoreCard";
 import type { Product } from "@/core/domain/product";
@@ -16,6 +17,7 @@ import { triggerHaptic, HAPTIC_PATTERNS } from "@/core/services/haptic-service";
 
 export default function ResultPage() {
   const params = useParams();
+  const router = useRouter();
   const barcode = params.barcode as string;
 
   const [product, setProduct] = useState<Product | null>(null);


### PR DESCRIPTION
## Summary

In ,  used  for a hard page reload. This has been replaced with  for soft navigation, consistent with the rest of the app.

## Why

- Hard navigation reloads the entire page + JS bundle — slower
- Client-side state from the previous page is lost unnecessarily
- Mix of hard/soft navigation is harder to debug
- No transition/animation effect compared to 

## Changes

-  → 
-  is already imported and used in this file (line 4: )

## Testing

- [ ] Scan a product → result page loads
- [ ] Click "Erneut scannen" → should navigate to  without full page reload
- [ ] Browser back button from  should return to result page

Closes #131